### PR TITLE
Port report/export + forecast-correctness gaps from the original app

### DIFF
--- a/apps/web/app/(shell)/insights/cash-asleep-export.tsx
+++ b/apps/web/app/(shell)/insights/cash-asleep-export.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ExportBar, type ExportColumn } from "@/lib/export/export-bar";
+import { useCurrency } from "@/components/currency-provider";
+import type { CashExportRow } from "@/lib/data/insights";
+
+/**
+ * Export controls for the insights "cash asleep" table. Client-side because
+ * ExportBar builds the file in the browser; the rows are every idle row the
+ * server ranked (the on-screen table pages to a handful), so the download is the
+ * full list rather than the page you can see.
+ *
+ * Frozen cash is a cost figure and rides the money-blind gate — dropped from the
+ * columns entirely for a member without view_costs, so the file never carries a
+ * masked cell. The other columns are derived, not money, so they stay for every
+ * role.
+ */
+
+/** Days-cover cell: whole days, or a dash when there is no rate to measure. */
+const coverCell = (days: number | null): string => (days == null ? "—" : `${days}d`);
+
+/** Exported for tests: money-blind members get no frozen-cash column. */
+export function cashExportColumns(
+  canViewCosts: boolean,
+  currency: string
+): ExportColumn<CashExportRow>[] {
+  return [
+    { header: "Product", cell: (r) => r.title },
+    { header: "SKU", cell: (r) => r.sku },
+    { header: "Vendor", cell: (r) => r.vendor ?? "" },
+    { header: "Days cover", cell: (r) => coverCell(r.coverDays) },
+    ...(canViewCosts
+      ? ([{ header: `Frozen cash (${currency})`, cell: (r) => r.cashKes }] satisfies ExportColumn<CashExportRow>[])
+      : []),
+    { header: "Risk", cell: (r) => r.risk },
+    { header: "Recommended action", cell: (r) => r.action },
+  ];
+}
+
+export function CashAsleepExportBar({
+  rows,
+  canViewCosts,
+}: {
+  /** Every idle row — the size of the file, not the paged table. */
+  rows: CashExportRow[];
+  canViewCosts: boolean;
+}) {
+  const currency = useCurrency();
+  return (
+    <ExportBar
+      rows={rows}
+      columns={cashExportColumns(canViewCosts, currency)}
+      filename="cash-asleep"
+      size="sm"
+    />
+  );
+}

--- a/apps/web/app/(shell)/insights/export-pdf-button.tsx
+++ b/apps/web/app/(shell)/insights/export-pdf-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { exportSectionPdf, type PdfColumn } from "@/lib/export/print-pdf";
+
+/**
+ * "Export PDF" for one Insights table — the branded, server-rendered counterpart
+ * to the CSV export. The server component hands over the exact columns and rows
+ * it just rendered, so the download matches the screen (and its cost redaction)
+ * by construction; the button only ships them to /api/reports/section-pdf and
+ * saves the blob.
+ *
+ * Own busy/error state rather than a toast, mirroring the check-now button on
+ * this page — the app has no toast bridge.
+ */
+export function ExportPdfButton({
+  title,
+  subtitle,
+  columns,
+  rows,
+  note,
+}: {
+  title: string;
+  subtitle?: string;
+  columns: PdfColumn[];
+  rows: (string | number | null | undefined)[][];
+  note?: string;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  async function run() {
+    setBusy(true);
+    setFailed(false);
+    const ok = await exportSectionPdf({ title, subtitle, columns, rows, note });
+    setFailed(!ok);
+    setBusy(false);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {failed && (
+        <span role="status" className="text-xs text-ink-muted">
+          Couldn&apos;t build the PDF — try again.
+        </span>
+      )}
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => void run()}
+        loading={busy}
+        disabled={rows.length === 0}
+      >
+        Export PDF
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/insights/page.tsx
+++ b/apps/web/app/(shell)/insights/page.tsx
@@ -109,7 +109,11 @@ export default async function InsightsPage({
             </div>
           }
         >
-          <ShelfHealth tenantId={membership.tenantId} canViewCosts={canViewCosts} />
+          <ShelfHealth
+            tenantId={membership.tenantId}
+            canViewCosts={canViewCosts}
+            currency={membership.tenant.currency}
+          />
         </Suspense>
       ) : (
         <div className="space-y-6">

--- a/apps/web/app/(shell)/insights/shelf-health.tsx
+++ b/apps/web/app/(shell)/insights/shelf-health.tsx
@@ -4,7 +4,9 @@ import { getInsightsOverview } from "@/lib/data/insights";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { CostValue } from "@/components/ui/cost-value";
-import { formatNumber } from "@/lib/money";
+import { formatMoney, formatNumber } from "@/lib/money";
+import { cols } from "@/lib/export/print-pdf";
+import { ExportPdfButton } from "./export-pdf-button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { StatTile } from "@/components/ui/stat-tile";
 import {
@@ -15,6 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { CashAsleepExportBar } from "./cash-asleep-export";
 
 /** Day and month, from the stored UTC date — a date-keyed row must not shift for
  *  a reader west of UTC. */
@@ -24,12 +27,17 @@ const dayLabel = (d: Date): string =>
 export async function ShelfHealth({
   tenantId,
   canViewCosts,
+  currency,
 }: {
   tenantId: string;
   canViewCosts: boolean;
+  currency: string;
 }) {
   const overview = await getInsightsOverview(tenantId, { canViewCosts });
   const { stockouts, deadStock, shelfRows, cashRows, cashTotalKes } = overview;
+  // Every idle row (the CSV is the whole list, not the paged table), aliased so
+  // it doesn't collide with the PDF's on-screen `cashExport` matrix below.
+  const cashExportRows = overview.cashExport;
 
   if (stockouts.trackedProducts === 0) {
     return (
@@ -41,6 +49,34 @@ export async function ShelfHealth({
   }
 
   const missedPerDay = shelfRows.reduce((sum, r) => sum + r.missedSalesKes, 0);
+
+  // Export tables mirror the on-screen columns and honour the same cost
+  // redaction — a money-blind caller's rows never carry a cash figure. Rebuilt
+  // from the same rows the tables render, so the PDF can't drift from the screen.
+  const shelfExport = {
+    columns: cols(["Product", "SKU", "Normally sells/day", "Missing/day", "Last sold"], [2, 3]),
+    rows: shelfRows.map((r) => [
+      r.title,
+      r.sku,
+      r.runRatePerDay.toFixed(1),
+      formatMoney(r.missedSalesKes, currency),
+      r.lastSoldAt ? dayLabel(r.lastSoldAt) : "never",
+    ]),
+  };
+  const cashHeaders = ["Product", "SKU", "Why", "On hand", "Cover"];
+  const cashExport = {
+    columns: cols(canViewCosts ? [...cashHeaders, `Cash tied up`] : cashHeaders, [3, 4, 5]),
+    rows: cashRows.map((r) => [
+      r.title,
+      r.sku,
+      r.reason === "not_selling" ? "Not selling" : "Way too much",
+      formatNumber(r.onHandUnits),
+      r.coverDays == null ? "—" : `${Math.round(r.coverDays)}d`,
+      ...(canViewCosts
+        ? [r.costKnown && r.cashKes != null ? formatMoney(r.cashKes, currency) : "—"]
+        : []),
+    ]),
+  };
 
   return (
     <div className="space-y-6">
@@ -77,12 +113,20 @@ export async function ShelfHealth({
           subtitle="Ranked by what they normally sell"
           action={
             shelfRows.length > 0 ? (
-              <Link
-                href="/plan"
-                className="flex h-9 items-center rounded-md bg-accent px-3 text-sm font-medium text-on-accent transition-colors hover:bg-accent-strong"
-              >
-                Plan a restock
-              </Link>
+              <div className="flex items-center gap-2">
+                <ExportPdfButton
+                  title="Empty shelves"
+                  subtitle="Ranked by what they normally sell"
+                  columns={shelfExport.columns}
+                  rows={shelfExport.rows}
+                />
+                <Link
+                  href="/plan"
+                  className="flex h-9 items-center rounded-md bg-accent px-3 text-sm font-medium text-on-accent transition-colors hover:bg-accent-strong"
+                >
+                  Plan a restock
+                </Link>
+              </div>
             ) : undefined
           }
         />
@@ -127,12 +171,28 @@ export async function ShelfHealth({
           title="Cash asleep on the shelf"
           subtitle="Stock that isn't turning — money you could be spending on what sells"
           action={
-            <CostValue
-              amount={cashTotalKes}
-              canViewCosts={canViewCosts}
-              compact
-              className="font-mono text-lg"
-            />
+            <div className="flex items-center gap-3">
+              {/* The CSV is every idle row, not the paged table above — offered
+                  wherever the list is, gated to any authenticated member (the
+                  cost column drops for a money-blind one). */}
+              {cashExportRows.length > 0 && (
+                <CashAsleepExportBar rows={cashExportRows} canViewCosts={canViewCosts} />
+              )}
+              {cashRows.length > 0 && (
+                <ExportPdfButton
+                  title="Cash asleep on the shelf"
+                  subtitle="Stock that isn't turning"
+                  columns={cashExport.columns}
+                  rows={cashExport.rows}
+                />
+              )}
+              <CostValue
+                amount={cashTotalKes}
+                canViewCosts={canViewCosts}
+                compact
+                className="font-mono text-lg"
+              />
+            </div>
           }
         />
         <CardContent>

--- a/apps/web/app/(shell)/today/dead-stock-export.tsx
+++ b/apps/web/app/(shell)/today/dead-stock-export.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ExportBar, type ExportColumn } from "@/lib/export/export-bar";
+import { useCurrency } from "@/components/currency-provider";
+import type { DeadStockExportRow } from "@/lib/data/today";
+
+/**
+ * Export controls for the dashboard's dead-stock tab. Client-side because
+ * ExportBar builds the file in the browser; the rows are the whole dead pile the
+ * server already computed (capped only for the on-screen table), so the download
+ * is the full list rather than the page you can see.
+ *
+ * Value at cost is a cost figure and rides the money-blind gate — it is dropped
+ * from the columns entirely for a member without view_costs, so the file never
+ * carries a masked cell. Value at retail is a sales figure and stays for every
+ * role.
+ */
+
+/** ISO date (UTC) — a date-keyed cell must not shift for a reader west of UTC,
+ *  and yyyy-mm-dd is the one form a spreadsheet reliably reads as a date. */
+const isoDay = (d: Date | null): string => (d ? d.toISOString().slice(0, 10) : "never");
+
+/** Exported for tests: money-blind members get no value-at-cost column. */
+export function deadStockExportColumns(
+  canViewCosts: boolean,
+  currency: string
+): ExportColumn<DeadStockExportRow>[] {
+  return [
+    { header: "SKU", cell: (r) => r.sku },
+    { header: "Product", cell: (r) => r.title },
+    { header: "Brand", cell: (r) => r.vendor ?? "" },
+    { header: "On hand", cell: (r) => r.onHandUnits },
+    { header: "Last sale", cell: (r) => isoDay(r.lastSaleAt) },
+    { header: "Days since last sale", cell: (r) => r.daysSinceLastSale },
+    ...(canViewCosts
+      ? ([{ header: `Value at cost (${currency})`, cell: (r) => r.valueAtCostKes }] satisfies ExportColumn<DeadStockExportRow>[])
+      : []),
+    { header: `Value at retail (${currency})`, cell: (r) => r.valueAtRetailKes },
+  ];
+}
+
+export function DeadStockExportBar({
+  rows,
+  canViewCosts,
+}: {
+  /** The whole dead pile — the size of the file, not the capped tab. */
+  rows: DeadStockExportRow[];
+  canViewCosts: boolean;
+}) {
+  const currency = useCurrency();
+  return (
+    <ExportBar
+      rows={rows}
+      columns={deadStockExportColumns(canViewCosts, currency)}
+      filename="dead-stock"
+      size="sm"
+    />
+  );
+}

--- a/apps/web/app/(shell)/today/product-tabs.tsx
+++ b/apps/web/app/(shell)/today/product-tabs.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/cn";
 import { formatNumber } from "@/lib/money";
 import type { CatalogueRow } from "@/lib/data/stock";
 import type { DashboardTab, DashboardTable } from "@/lib/data/today";
+import { DeadStockExportBar } from "./dead-stock-export";
 
 /**
  * The morning's products, in the five piles worth looking at, with the four
@@ -231,6 +232,13 @@ export function ProductTabs({
             <span className="ml-auto text-2xs text-ink-muted">
               showing the first {rows.length} of {formatNumber(data.counts[tab])}
             </span>
+          )}
+          {/* The download is the whole dead pile, not the capped page above —
+              offered on this tab only, where the file has a definition. */}
+          {tab === "dead" && data.deadStockExport.length > 0 && (
+            <div className={data.capped[tab] ? "" : "ml-auto"}>
+              <DeadStockExportBar rows={data.deadStockExport} canViewCosts={canViewCosts} />
+            </div>
           )}
         </div>
 

--- a/apps/web/app/api/reports/pdf/route.ts
+++ b/apps/web/app/api/reports/pdf/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import { BUYABLE_PRODUCT_WHERE, prismaForTenant } from "@wezesha/db";
+import { activeMembership, getSession } from "@/lib/auth";
+import { hasPermission } from "@/lib/auth/permissions";
+import { getTodayMetrics } from "@/lib/data/today";
+import { renderReportPdf, type ReportPdfData } from "@/lib/reports/report-pdf";
+import { withCapture } from "@/lib/observability/wrap";
+
+// react-pdf needs the Node runtime (not edge).
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+const DAY_MS = 86_400_000;
+
+/**
+ * GET /api/reports/pdf — a one-page shop performance report.
+ *
+ * Session-guarded and scoped to the caller's active membership; any authenticated
+ * member may export (there is no separate export permission). Cost figures —
+ * capital tied up, dead-stock value — are dropped for a member without
+ * `view_costs`, so a money-blind role's PDF never carries them.
+ *
+ * The headline counts (revenue, stockouts, dead stock) come from getTodayMetrics
+ * so this report and the Today/Insights screens can never disagree. ABC mix,
+ * capital and the top-movers table are the report's own, read on the same
+ * RLS-enforced tenant client.
+ */
+export const GET = withCapture(
+  async () => {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const membership = await activeMembership(session.user.id);
+    if (!membership) {
+      return NextResponse.json({ error: "no workspace" }, { status: 403 });
+    }
+
+    const canSeeCosts = hasPermission(membership, "view_costs");
+    const tenantId = membership.tenantId;
+    const db = prismaForTenant(tenantId);
+    const since30 = new Date(Date.now() - 30 * DAY_MS);
+
+    const [today, products, sales30] = await Promise.all([
+      getTodayMetrics(tenantId, { canViewCosts: canSeeCosts }),
+      db.product.findMany({
+        where: { ...BUYABLE_PRODUCT_WHERE },
+        select: { id: true, title: true, sku: true, costKes: true, currentStock: true, abcCategory: true },
+      }),
+      db.salesHistory.groupBy({
+        by: ["productId"],
+        where: { date: { gte: since30 } },
+        _sum: { quantity: true, revenueKes: true },
+      }),
+    ]);
+
+    // ABC mix + capital tied up, walked once over the buyable catalogue.
+    const abc = { A: 0, B: 0, C: 0 };
+    let capital = 0;
+    for (const p of products) {
+      capital += p.currentStock * p.costKes;
+      if (p.abcCategory === "A") abc.A++;
+      else if (p.abcCategory === "B") abc.B++;
+      else if (p.abcCategory === "C") abc.C++;
+    }
+
+    const last30Rev = sales30.reduce((sum, s) => sum + (s._sum.revenueKes ?? 0), 0);
+
+    const productById = new Map(products.map((p) => [p.id, p]));
+    const topMovers = sales30
+      .map((s) => ({ p: productById.get(s.productId), rev: s._sum.revenueKes ?? 0, qty: s._sum.quantity ?? 0 }))
+      .filter((x): x is { p: NonNullable<typeof x.p>; rev: number; qty: number } => x.p != null)
+      .sort((a, b) => b.rev - a.rev)
+      .slice(0, 10)
+      .map((x) => ({ title: x.p.title, sku: x.p.sku, qty: Math.round(x.qty), rev: x.rev }));
+
+    const data: ReportPdfData = {
+      shop: {
+        name: membership.tenant.name,
+        timezone: membership.tenant.timezone,
+        currency: membership.tenant.currency,
+      },
+      generatedAt: new Date(),
+      canSeeCosts,
+      last30Rev,
+      capitalCost: canSeeCosts ? capital : null,
+      abc,
+      topMovers,
+      deadStock: { count: today.deadStock.skus, valueKes: today.deadStock.costKes },
+      stockoutCount: today.stockedOutProducts,
+    };
+
+    const pdf = await renderReportPdf(data);
+    return new NextResponse(new Uint8Array(pdf), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="report.pdf"`,
+      },
+    });
+  },
+  { route: "/api/reports/pdf", errorMessage: "report pdf build failed" }
+);

--- a/apps/web/app/api/reports/section-pdf/route.ts
+++ b/apps/web/app/api/reports/section-pdf/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { activeMembership, getSession } from "@/lib/auth";
+import { hasPermission } from "@/lib/auth/permissions";
+import { renderSectionPdf, type SectionPdfData } from "@/lib/reports/section-pdf";
+import { withCapture } from "@/lib/observability/wrap";
+
+// react-pdf needs the Node runtime (not edge).
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+/**
+ * POST /api/reports/section-pdf — render ONE analytics section as a branded PDF.
+ *
+ * The client sends the already-computed table it is showing (title, columns,
+ * rows, optional KPI cards) — so whatever filter is on screen is honoured by
+ * construction — and the server formats it. Keeps react-pdf out of the browser
+ * bundle and the output consistent with the shop report.
+ *
+ * Session-guarded and scoped to the caller's active membership; any authenticated
+ * member may export. The body is untrusted, so it is hardened: title capped,
+ * columns cut to a sane maximum (empty = 400), rows capped and every cell coerced
+ * to a string. The shop name/timezone and the cost-visibility flag come from the
+ * membership, never from the request.
+ */
+export const POST = withCapture(
+  async (req: NextRequest) => {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const membership = await activeMembership(session.user.id);
+    if (!membership) {
+      return NextResponse.json({ error: "no workspace" }, { status: 403 });
+    }
+
+    let body: {
+      title?: string;
+      subtitle?: string;
+      kpis?: { label: string; value: string }[];
+      columns?: { header: string; width?: number; align?: "left" | "right" }[];
+      rows?: (string | number | null)[][];
+      note?: string;
+    };
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "invalid body" }, { status: 400 });
+    }
+
+    const title = (body.title ?? "Report").toString().slice(0, 80);
+    const columns = Array.isArray(body.columns) ? body.columns.slice(0, 12) : [];
+    if (columns.length === 0) {
+      return NextResponse.json({ error: "no columns" }, { status: 400 });
+    }
+
+    // Coerce every cell to a string; cap rows so a huge list can't blow the render.
+    const rows = (Array.isArray(body.rows) ? body.rows : [])
+      .slice(0, 500)
+      .map((r) => columns.map((_, i) => (r[i] == null ? "" : String(r[i]))));
+
+    const data: SectionPdfData = {
+      shop: { name: membership.tenant.name, timezone: membership.tenant.timezone },
+      generatedAt: new Date(),
+      title,
+      subtitle: body.subtitle?.toString().slice(0, 160),
+      kpis: Array.isArray(body.kpis)
+        ? body.kpis.slice(0, 5).map((k) => ({
+            label: String(k.label).slice(0, 40),
+            value: String(k.value).slice(0, 40),
+          }))
+        : undefined,
+      columns,
+      rows,
+      note: body.note?.toString().slice(0, 200),
+      canSeeCosts: hasPermission(membership, "view_costs"),
+    };
+
+    const buffer = await renderSectionPdf(data);
+    const filename = `${title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "report"}.pdf`;
+    return new NextResponse(new Uint8Array(buffer), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  },
+  { route: "/api/reports/section-pdf", errorMessage: "section pdf build failed" }
+);

--- a/apps/web/lib/data/insights.ts
+++ b/apps/web/lib/data/insights.ts
@@ -58,6 +58,29 @@ export type CashAsleepRow = {
   costKnown: boolean;
 };
 
+/**
+ * One idle-capital line as the full-list CSV wants it. The on-screen "cash
+ * asleep" table pages to a handful of rows; the download is every idle row the
+ * shop has, with the vendor and the plain-words action the file names.
+ *
+ * Frozen cash is a cost figure and carries the money-blind redaction — null for
+ * a caller without view_costs. Days cover and the risk/action words are
+ * derived, not money, so they stay for every role.
+ */
+export type CashExportRow = {
+  title: string;
+  sku: string;
+  vendor: string | null;
+  /** Whole days of cover; null when there is no run rate to divide by. */
+  coverDays: number | null;
+  /** cost × on-hand. Null for a money-blind caller. */
+  cashKes: number | null;
+  /** The risk pile in the table's own words. */
+  risk: "Not selling" | "Way too much";
+  /** What to do about this pile, in plain words. */
+  action: string;
+};
+
 export type InsightsOverview = {
   stockouts: {
     /** Canonical count — the same number Today shows. */
@@ -74,9 +97,19 @@ export type InsightsOverview = {
   shelfRows: EmptyShelfRow[];
   /** Idle capital ranked by cash frozen. */
   cashRows: CashAsleepRow[];
+  /** EVERY idle row for the CSV — not the page `cashRows` shows — in the same
+   *  ranking, carrying the vendor and plain-words action the file names. */
+  cashExport: CashExportRow[];
   /** Total cash across every idle row, not just the returned page. */
   cashTotalKes: number | null;
   overstockCoverDays: number;
+};
+
+/** The plain-words next step for each idle pile — the file spells out what the
+ *  badge implies. Kept beside the type so table and CSV read the same. */
+const CASH_ACTION: Record<CashAsleepRow["reason"], string> = {
+  not_selling: "Discount / stop reorder",
+  too_much: "Slow reorder",
 };
 
 const redactCashRow = (r: CashAsleepRow): CashAsleepRow => ({ ...r, cashKes: null });
@@ -113,12 +146,13 @@ export async function getInsightsOverview(
     getCatalogueMetrics(tenantId),
     db.product.findMany({
       where: { ...BUYABLE_PRODUCT_WHERE },
-      select: { id: true, sku: true, title: true, priceKes: true, costKes: true, currentStock: true },
+      select: { id: true, sku: true, title: true, vendor: true, priceKes: true, costKes: true, currentStock: true },
     }),
     db.salesHistory.groupBy({ by: ["productId"], _max: { date: true } }),
   ]);
 
   const lastSale = new Map(lastSales.map((s) => [s.productId, s._max.date]));
+  const vendorById = new Map(products.map((p) => [p.id, p.vendor]));
   const deadCutoff = Date.now() - today.deadStock.windowDays * 86_400_000;
 
   const shelfRows: EmptyShelfRow[] = [];
@@ -172,6 +206,19 @@ export async function getInsightsOverview(
   const pagedShelf = shelfRows.slice(0, limit);
   const pagedCash = cashRows.slice(0, limit);
 
+  // The CSV is every idle row in the same ranking, not the page — with the
+  // vendor and the plain-words action added and the same cost redaction as the
+  // table (frozen cash nulled for a money-blind caller).
+  const cashExport: CashExportRow[] = cashRows.map((r) => ({
+    title: r.title,
+    sku: r.sku,
+    vendor: vendorById.get(r.productId) ?? null,
+    coverDays: r.coverDays == null ? null : Math.round(r.coverDays),
+    cashKes: canViewCosts && r.costKnown ? r.cashKes : null,
+    risk: r.reason === "not_selling" ? "Not selling" : "Way too much",
+    action: CASH_ACTION[r.reason],
+  }));
+
   return {
     stockouts: {
       skus: today.stockedOutProducts,
@@ -184,6 +231,7 @@ export async function getInsightsOverview(
     deadStock: today.deadStock,
     shelfRows: pagedShelf,
     cashRows: canViewCosts ? pagedCash : pagedCash.map(redactCashRow),
+    cashExport,
     cashTotalKes: canViewCosts ? cashTotal : null,
     overstockCoverDays: OVERSTOCK_COVER_DAYS,
   };

--- a/apps/web/lib/data/today.ts
+++ b/apps/web/lib/data/today.ts
@@ -189,6 +189,31 @@ export async function getReorderNeeded(
 /** The five piles the dashboard table tabs between. */
 export type DashboardTab = "stockout" | "reorder" | "onway" | "dead" | "all";
 
+/**
+ * One dead-stock line as the CSV wants it. The dashboard table caps its dead
+ * pile at the row limit and shows cost/capital only; the download is the whole
+ * pile with the last-sale facts the export names, so the file is not "the
+ * twenty-five rows you happen to be looking at".
+ *
+ * Value at cost carries the same redaction as everywhere else — null for a
+ * money-blind caller. Value at retail is price × on-hand, a sales figure, so it
+ * stays visible to every role.
+ */
+export type DeadStockExportRow = {
+  sku: string;
+  title: string;
+  vendor: string | null;
+  onHandUnits: number;
+  lastSaleAt: Date | null;
+  /** Whole days since the last sale; null when nothing has ever sold. */
+  daysSinceLastSale: number | null;
+  /** cost × on-hand — the same money-at-rest figure the tab shows. Null for a
+   *  money-blind caller. */
+  valueAtCostKes: number | null;
+  /** price × on-hand — a sales figure, visible to every role. */
+  valueAtRetailKes: number;
+};
+
 export type DashboardTable = {
   /** Full counts — the tab pills and the health panel read these, never the
    *  length of the capped rows below. */
@@ -209,6 +234,10 @@ export type DashboardTable = {
   /** True when a pile had more rows than the cap, so the screen can say so
    *  rather than quietly showing a prefix. */
   capped: Record<DashboardTab, boolean>;
+  /** The FULL dead pile for the CSV — every dead row, not the capped page the
+   *  `dead` tab renders — ranked by frozen cash (cost when visible, else
+   *  retail) so the file leads with the most capital sitting still. */
+  deadStockExport: DeadStockExportRow[];
 };
 
 const DASHBOARD_ROW_CAP = 25;
@@ -286,6 +315,33 @@ export async function getDashboardTable(
     capped_rows[key] = piles[key].slice(0, limit);
   }
 
+  // The export takes the whole dead pile, not the capped page, and adds the
+  // last-sale facts the file names. On-hand, cost and price all come from the
+  // catalogue row, so the numbers match the tab; last sale is the map already
+  // fetched for the piling. Ranked by frozen cash — cost when the caller can see
+  // it, retail otherwise — so a money-blind file still leads with the biggest
+  // pile of unsold stock rather than sorting on a redacted null.
+  const now = Date.now();
+  const deadStockExport: DeadStockExportRow[] = piles.dead
+    .map((row) => {
+      const last = lastSale.get(row.productId) ?? null;
+      return {
+        sku: row.sku,
+        title: row.title,
+        vendor: row.vendor,
+        onHandUnits: row.onHandUnits,
+        lastSaleAt: last,
+        daysSinceLastSale: last ? Math.floor((now - last.getTime()) / DAY_MS) : null,
+        valueAtCostKes: row.moneyAtRestKes,
+        valueAtRetailKes: row.priceKes * Math.max(0, row.onHandUnits),
+      };
+    })
+    .sort(
+      (a, b) =>
+        (canViewCosts ? (b.valueAtCostKes ?? 0) - (a.valueAtCostKes ?? 0) : 0) ||
+        b.valueAtRetailKes - a.valueAtRetailKes
+    );
+
   return {
     counts,
     healthy,
@@ -297,5 +353,6 @@ export async function getDashboardTable(
       : null,
     criticalCount: (buyList?.rows ?? []).filter((r) => r.urgency === "critical").length,
     capped,
+    deadStockExport,
   };
 }

--- a/apps/web/lib/data/transfers.ts
+++ b/apps/web/lib/data/transfers.ts
@@ -6,7 +6,45 @@ import {
   sellableUnits,
   type LocationRole,
 } from "@wezesha/db";
+import {
+  sizeTransfers,
+  destinationShares,
+  clampCoverDays,
+  clampWindowDays,
+  NO_RATE_EPSILON,
+  DEFAULT_COVER_DAYS,
+  DEFAULT_WINDOW_DAYS,
+  COVER_DAY_CHOICES,
+  MIN_COVER_DAYS,
+  MAX_COVER_DAYS,
+  MIN_WINDOW_DAYS,
+  MAX_WINDOW_DAYS,
+  type DestinationPosition,
+  type SizedTransfer,
+  type RateBasis,
+} from "@wezesha/forecast";
 import { getCatalogueMetrics } from "@/lib/metrics";
+
+// The pure sizing engine now lives in @wezesha/forecast so the worker's owner
+// report can size the same warehouse→branch moves without importing this
+// web-only module. Re-exported here so this file's many consumers (the
+// distribution page, actions, tests) keep their existing import paths.
+export {
+  sizeTransfers,
+  destinationShares,
+  clampCoverDays,
+  clampWindowDays,
+  DEFAULT_COVER_DAYS,
+  DEFAULT_WINDOW_DAYS,
+  COVER_DAY_CHOICES,
+  MIN_COVER_DAYS,
+  MAX_COVER_DAYS,
+  MIN_WINDOW_DAYS,
+  MAX_WINDOW_DAYS,
+  type DestinationPosition,
+  type SizedTransfer,
+  type RateBasis,
+};
 
 /**
  * Transfers — "what to move, from where to where, and why". A distribution plan
@@ -35,204 +73,6 @@ import { getCatalogueMetrics } from "@/lib/metrics";
  */
 
 const DAY_MS = 86_400_000;
-
-/** At or below this a destination has no measurable velocity — cover is
- *  undefined there. Matches the stock screen's "no run rate" threshold. */
-const NO_RATE_EPSILON = 0.0001;
-
-/** Target days of cover a plan levels every destination up to. */
-export const DEFAULT_COVER_DAYS = 14;
-
-/** Trailing window used to attribute demand to a branch. */
-export const DEFAULT_WINDOW_DAYS = 90;
-
-/** Cover horizons offered on the screen. */
-export const COVER_DAY_CHOICES = [7, 14, 30] as const;
-
-/** Guard rails for anything a client can influence. */
-export const MIN_COVER_DAYS = 1;
-export const MAX_COVER_DAYS = 180;
-export const MIN_WINDOW_DAYS = 7;
-export const MAX_WINDOW_DAYS = 365;
-
-// ── The sizing engine (pure) ─────────────────────────────────────────────────
-
-export type DestinationPosition = {
-  locationId: string;
-  /** On-hand at this destination today. Negative = oversold: a hole to backfill. */
-  onHand: number;
-  /** This destination's share of the product's run rate (units/day). */
-  runRate: number;
-};
-
-export type SizedTransfer = {
-  toLocationId: string;
-  /** Whole units to move. Never fractional, never more than the source holds. */
-  qty: number;
-  toOnHand: number;
-  toRunRate: number;
-  toDaysCoverBefore: number;
-  toDaysCoverAfter: number;
-};
-
-const roundTo1 = (value: number): number => Math.round(value * 10) / 10;
-
-/** Units a destination is short of a given cover level. Negative on-hand raises
- *  the need — the hole is real stock the branch owes its shelf. */
-const shortfall = (d: DestinationPosition, level: number): number =>
-  Math.max(0, d.runRate * level - d.onHand);
-
-/**
- * The highest common cover level the available units can lift every destination
- * to (the classic level-fill). Exact rather than iterative: each destination
- * starts needing stock at level `onHand / runRate`, so walking those breakpoints
- * in order gives a segment on which the total need is linear in the level, and
- * the level is solved directly on the first segment that fits.
- */
-function fillLevel(destinations: DestinationPosition[], available: number): number {
-  const points = [...destinations].sort((a, b) => a.onHand / a.runRate - b.onHand / b.runRate);
-  let rate = 0;
-  let onHand = 0;
-  for (let i = 0; i < points.length; i++) {
-    rate += points[i]!.runRate;
-    onHand += points[i]!.onHand;
-    const next = points[i + 1];
-    const level = (available + onHand) / rate;
-    if (!next || level <= next.onHand / next.runRate) return level;
-  }
-  return 0; // unreachable: the last segment has no upper breakpoint
-}
-
-/**
- * Size one product's move out of a source holding `available` units.
- *
- * The rule: level-fill to a common days-of-cover. Every destination is lifted to
- * the same cover level — the target when the source can afford it, otherwise the
- * highest level the source can reach for everyone. That is what "equalise cover"
- * means; the alternative, splitting the shortfall proportionally, *preserves*
- * the imbalance it is meant to remove (the branch that started emptiest stays
- * emptiest), so it is used only to settle the rounding remainder below.
- *
- * The decisions this encodes, in order:
- *
- * 1. No run rate at a destination (`runRate <= NO_RATE_EPSILON`) → it receives
- *    nothing. There is no cover to equalise, and shipping stock to a branch with
- *    no measured demand manufactures the dead stock the product exists to kill.
- *    Opening stock for a genuinely new branch is a deliberate manual decision,
- *    not something a demand-driven plan should invent. Callers surface these
- *    destinations rather than dropping them silently.
- * 2. The source holds none of the product (`available <= 0`) → no lines. A
- *    negative (oversold) source position is treated as zero, never as a debt to
- *    push onto branches.
- * 3. Already at or above the level → that destination gets nothing; the units
- *    stay in the warehouse for the branches that are short.
- * 4. Source can't satisfy everyone → level-fill (above), which spends every
- *    available unit on the branches furthest below the achievable common cover.
- * 5. Rounding → floor each destination's fractional need, then hand the leftover
- *    whole units out by largest fractional part (ties to the faster seller, then
- *    by location id so the plan is deterministic). Total moved never exceeds the
- *    floor of what the source holds, and never exceeds the total need — the plan
- *    under-ships by at most one unit rather than over-shipping, because the unit
- *    left in the warehouse is still available to anyone.
- */
-export function sizeTransfers(
-  available: number,
-  destinations: DestinationPosition[],
-  coverDays: number
-): SizedTransfer[] {
-  const units = Math.floor(Math.max(0, available));
-  const candidates = destinations.filter((d) => d.runRate > NO_RATE_EPSILON);
-  if (units <= 0 || candidates.length === 0) return [];
-
-  const needAtTarget = candidates.reduce((sum, d) => sum + shortfall(d, coverDays), 0);
-  if (needAtTarget <= 0) return [];
-
-  const level = needAtTarget <= units ? coverDays : fillLevel(candidates, units);
-
-  const wants = candidates
-    .map((d) => ({ d, want: shortfall(d, level) }))
-    .filter((w) => w.want > 0);
-  if (wants.length === 0) return [];
-
-  // Float slack on the total only: the level solve lands on sums like 3.999…7,
-  // and flooring that raw would silently strand a unit. Per-destination floors
-  // stay exact so the floors can never out-run the budget.
-  const budget = Math.min(units, Math.floor(wants.reduce((sum, w) => sum + w.want, 0) + 1e-9));
-  const qtyByLocation = new Map(wants.map((w) => [w.d.locationId, Math.floor(w.want)]));
-  let spare = budget - [...qtyByLocation.values()].reduce((sum, q) => sum + q, 0);
-
-  const byRemainder = [...wants].sort(
-    (a, b) =>
-      (b.want - Math.floor(b.want)) - (a.want - Math.floor(a.want)) ||
-      b.d.runRate - a.d.runRate ||
-      a.d.locationId.localeCompare(b.d.locationId)
-  );
-  for (const w of byRemainder) {
-    if (spare <= 0) break;
-    qtyByLocation.set(w.d.locationId, (qtyByLocation.get(w.d.locationId) ?? 0) + 1);
-    spare -= 1;
-  }
-
-  return wants
-    .map(({ d }) => {
-      const qty = qtyByLocation.get(d.locationId) ?? 0;
-      return {
-        toLocationId: d.locationId,
-        qty,
-        toOnHand: d.onHand,
-        toRunRate: d.runRate,
-        toDaysCoverBefore: roundTo1(Math.max(0, d.onHand) / d.runRate),
-        toDaysCoverAfter: roundTo1(Math.max(0, d.onHand + qty) / d.runRate),
-      };
-    })
-    .filter((line) => line.qty > 0);
-}
-
-/** How a product's per-destination run rate was derived — always shown, never
- *  presented as if it were measured when it isn't. */
-export type RateBasis = "attributed" | "allocated" | "even";
-
-/**
- * Split a product's blended run rate across destinations. The blended rate stays
- * the one engine number; only its SHARE per branch is derived here, in this
- * order of evidence:
- *
- *   "attributed" — the branch's own attributed sales in the window
- *     (SalesHistory.locationId). The only basis that is measured, and the only
- *     one under which branches genuinely differ in cover.
- *   "allocated"  — no attributed sales for this product anywhere: fall back to
- *     each branch's share of the stock it holds, the same approximation the
- *     stock screen documents for per-branch cover (lib/data/stock.ts). Note this
- *     makes every stocked branch land on identical cover, so a plan built on it
- *     is really "split the warehouse by where the stock already sits".
- *   "even"       — neither signal: the product sells (it has a blended rate) but
- *     no branch holds it or has attributed history, i.e. a shop-wide stockout.
- *     Split evenly and refill every branch.
- */
-export function destinationShares(
-  destinations: { locationId: string; onHand: number; attributedUnits: number }[]
-): { basis: RateBasis; shareByLocation: Map<string, number> } {
-  const attributed = destinations.reduce((sum, d) => sum + Math.max(0, d.attributedUnits), 0);
-  if (attributed > 0) {
-    return {
-      basis: "attributed",
-      shareByLocation: new Map(
-        destinations.map((d) => [d.locationId, Math.max(0, d.attributedUnits) / attributed])
-      ),
-    };
-  }
-  const stocked = destinations.reduce((sum, d) => sum + Math.max(0, d.onHand), 0);
-  if (stocked > 0) {
-    return {
-      basis: "allocated",
-      shareByLocation: new Map(
-        destinations.map((d) => [d.locationId, Math.max(0, d.onHand) / stocked])
-      ),
-    };
-  }
-  const even = destinations.length > 0 ? 1 / destinations.length : 0;
-  return { basis: "even", shareByLocation: new Map(destinations.map((d) => [d.locationId, even])) };
-}
 
 // ── The proposal (live, unsaved) ─────────────────────────────────────────────
 
@@ -296,18 +136,6 @@ export type DistributionProposal = {
   /** True when at least one line rests on measured per-branch sales. */
   hasAttributedDemand: boolean;
 };
-
-/** Clamp a caller-supplied horizon into something a plan can be built on — the
- *  cover target rides in a URL and a re-size action, so neither is trusted. */
-export function clampCoverDays(value: number | undefined): number {
-  if (!Number.isFinite(value)) return DEFAULT_COVER_DAYS;
-  return Math.min(MAX_COVER_DAYS, Math.max(MIN_COVER_DAYS, Math.round(value as number)));
-}
-
-export function clampWindowDays(value: number | undefined): number {
-  if (!Number.isFinite(value)) return DEFAULT_WINDOW_DAYS;
-  return Math.min(MAX_WINDOW_DAYS, Math.max(MIN_WINDOW_DAYS, Math.round(value as number)));
-}
 
 /**
  * Locations a plan can ship FROM, warehouses first — the source picker. En-route

--- a/apps/web/lib/export/print-pdf.ts
+++ b/apps/web/lib/export/print-pdf.ts
@@ -1,0 +1,57 @@
+/**
+ * "Export this section as a PDF" — posts the on-screen table to the server, which
+ * renders a branded report (react-pdf) and streams it back as a real PDF
+ * download. A companion to the browser-print path in pdf.ts: this one produces a
+ * pixel-consistent branded document rather than a print dialog.
+ *
+ * Tenant is resolved from the session server-side (see /api/reports/section-pdf),
+ * so the fetch carries no tenant header — the same way every other client fetch
+ * in this app reaches its /api routes. Returns whether the download started so a
+ * button can surface its own error, since this app has no toast bridge.
+ *
+ * Client-only (touches the DOM).
+ */
+
+export type PdfColumn = { header: string; width?: number; align?: "left" | "right" };
+
+/** Build columns from a header list + the indexes that should right-align (numbers). */
+export function cols(headers: string[], rightAlign: number[] = []): PdfColumn[] {
+  const r = new Set(rightAlign);
+  return headers.map((h, i) => ({ header: h, align: r.has(i) ? "right" : "left" }));
+}
+
+/** Slugify a title into a safe filename stem, matching the server's own rule. */
+function slugify(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "report";
+}
+
+export async function exportSectionPdf(opts: {
+  title: string;
+  subtitle?: string;
+  kpis?: { label: string; value: string }[];
+  columns: PdfColumn[];
+  rows: (string | number | null | undefined)[][];
+  note?: string;
+}): Promise<boolean> {
+  try {
+    const res = await fetch("/api/reports/section-pdf", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(opts),
+    });
+    if (!res.ok) return false;
+
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${slugify(opts.title)}.pdf`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/lib/reports/report-pdf.tsx
+++ b/apps/web/lib/reports/report-pdf.tsx
@@ -1,0 +1,140 @@
+/**
+ * Shop performance report PDF (revenue, capital, ABC mix, dead stock, stockouts,
+ * top movers). Server-rendered via renderReportPdf() in the /api/reports/pdf
+ * route (runtime = "nodejs"), so it's a real branded document, not a browser
+ * print dump.
+ *
+ * PURE render function: no I/O, no Prisma, no dates-of-now. The route fetches
+ * and redacts, then hands everything in — tests can drive this directly.
+ *
+ * The brand string is parameterised (default "Wezesha Restock"), and money and
+ * dates read the shop's own currency and timezone rather than assuming KES /
+ * Nairobi — a workspace in another market must not see the wrong unit.
+ */
+import { Document, Page, Text, View, StyleSheet, renderToBuffer } from "@react-pdf/renderer";
+
+export type ReportPdfData = {
+  shop: { name: string; timezone: string; currency?: string };
+  generatedAt: Date;
+  canSeeCosts: boolean;
+  last30Rev: number;
+  capitalCost: number | null;
+  abc: { A: number; B: number; C: number };
+  topMovers: { title: string; sku: string; qty: number; rev: number }[];
+  deadStock: { count: number; valueKes: number | null };
+  stockoutCount: number;
+};
+
+const DEFAULT_BRAND = "Wezesha Restock";
+const DEFAULT_TZ = "Africa/Nairobi";
+const DEFAULT_CURRENCY = "KES";
+
+const INK = "#17171c";
+const MUTE = "#71717a";
+const LINE = "#e7e6ee";
+
+/** "KES 1,234", currency-aware. Not Intl currency style — a non-breaking space
+ *  between code and number is invisible in a diff and breaks string tests. */
+const money = (n: number, currency: string) =>
+  `${currency} ${Math.round(n).toLocaleString("en-KE")}`;
+
+/** Day/month/year in the shop's timezone — a date-keyed line must not shift for
+ *  a reader in another zone. Intl avoids pulling in date-fns-tz. */
+const fmtDate = (d: Date, tz: string) =>
+  new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: tz,
+  }).format(d);
+
+const s = StyleSheet.create({
+  page: { padding: 40, fontSize: 10, color: INK, fontFamily: "Helvetica" },
+  row: { flexDirection: "row", justifyContent: "space-between" },
+  brand: { fontSize: 16, fontFamily: "Helvetica-Bold", color: INK },
+  brandSub: { fontSize: 9, color: MUTE, marginTop: 2 },
+  title: { fontSize: 20, fontFamily: "Helvetica-Bold", textAlign: "right" },
+  meta: { fontSize: 9, color: MUTE, textAlign: "right", marginTop: 2 },
+  kpiRow: { flexDirection: "row", marginTop: 20, gap: 10 },
+  kpi: { flex: 1, borderWidth: 1, borderColor: LINE, borderRadius: 6, padding: 12 },
+  kpiLabel: { fontSize: 8, color: MUTE, textTransform: "uppercase", letterSpacing: 1 },
+  kpiVal: { fontSize: 14, fontFamily: "Helvetica-Bold", marginTop: 4 },
+  section: { marginTop: 28 },
+  label: { fontSize: 8, color: MUTE, textTransform: "uppercase", letterSpacing: 1, marginBottom: 6 },
+  tableHead: { flexDirection: "row", borderBottomWidth: 1, borderBottomColor: INK, paddingBottom: 6 },
+  tableRow: { flexDirection: "row", borderBottomWidth: 1, borderBottomColor: LINE, paddingVertical: 7 },
+  cProd: { flex: 1 },
+  cSold: { width: 70, textAlign: "right" },
+  cRev: { width: 110, textAlign: "right" },
+  sub: { fontSize: 8, color: MUTE, marginTop: 1 },
+  footer: { marginTop: 28, fontSize: 8, color: MUTE, textAlign: "center" },
+});
+
+function Kpi({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={s.kpi}>
+      <Text style={s.kpiLabel}>{label}</Text>
+      <Text style={s.kpiVal}>{value}</Text>
+    </View>
+  );
+}
+
+function ReportDocument({ data, brand }: { data: ReportPdfData; brand: string }) {
+  const tz = data.shop.timezone || DEFAULT_TZ;
+  const currency = data.shop.currency || DEFAULT_CURRENCY;
+  const kes = (n: number) => money(n, currency);
+  const dead = `${data.deadStock.count}${data.canSeeCosts && data.deadStock.valueKes != null ? ` · ${kes(data.deadStock.valueKes)}` : ""}`;
+  return (
+    <Document title={`${brand} performance report`}>
+      <Page size="A4" style={s.page}>
+        <View style={s.row}>
+          <View>
+            <Text style={s.brand}>{brand}</Text>
+            <Text style={s.brandSub}>{data.shop.name}</Text>
+          </View>
+          <View>
+            <Text style={s.title}>Performance report</Text>
+            <Text style={s.meta}>Generated {fmtDate(data.generatedAt, tz)}</Text>
+          </View>
+        </View>
+
+        <View style={s.kpiRow}>
+          <Kpi label="Last 30 days revenue" value={kes(data.last30Rev)} />
+          {data.canSeeCosts ? <Kpi label="Capital tied up (cost)" value={data.capitalCost == null ? "—" : kes(data.capitalCost)} /> : null}
+          <Kpi label="ABC mix" value={`${data.abc.A} · ${data.abc.B} · ${data.abc.C}`} />
+        </View>
+        <View style={s.kpiRow}>
+          <Kpi label="Dead stock (no 90d sale)" value={dead} />
+          <Kpi label="Stockouts (A/B at zero)" value={String(data.stockoutCount)} />
+        </View>
+
+        <View style={s.section}>
+          <Text style={s.label}>Top 10 movers — last 30 days</Text>
+          <View style={s.tableHead}>
+            <Text style={s.cProd}>Product</Text>
+            <Text style={s.cSold}>Sold</Text>
+            <Text style={s.cRev}>Revenue</Text>
+          </View>
+          {data.topMovers.length === 0 ? (
+            <Text style={{ color: MUTE, marginTop: 10 }}>No sales in the last 30 days.</Text>
+          ) : data.topMovers.map((m, i) => (
+            <View key={i} style={s.tableRow}>
+              <View style={s.cProd}><Text>{m.title}</Text><Text style={s.sub}>{m.sku}</Text></View>
+              <Text style={s.cSold}>{m.qty}</Text>
+              <Text style={s.cRev}>{kes(m.rev)}</Text>
+            </View>
+          ))}
+        </View>
+
+        <Text style={s.footer}>{brand} · figures reflect the last-synced data{data.canSeeCosts ? "" : " · cost figures hidden for your role"}</Text>
+      </Page>
+    </Document>
+  );
+}
+
+export function renderReportPdf(
+  data: ReportPdfData,
+  brand: string = DEFAULT_BRAND,
+): Promise<Buffer> {
+  return renderToBuffer(<ReportDocument data={data} brand={brand} />);
+}

--- a/apps/web/lib/reports/section-pdf.tsx
+++ b/apps/web/lib/reports/section-pdf.tsx
@@ -1,0 +1,139 @@
+/**
+ * Generic single-section report PDF — a branded document for ONE analytics table
+ * (empty shelves, dead stock, top movers, the accuracy trend, …). Server-rendered
+ * via renderToBuffer so it's a real PDF, not a browser print dump. Mirrors the
+ * styling of report-pdf.tsx (same brand header, KPI cards, table look).
+ *
+ * PURE render function: the route hardens and formats the input, then hands the
+ * already-string rows in. Dates read the shop's timezone via Intl (no
+ * date-fns-tz dependency).
+ */
+import { Document, Page, Text, View, StyleSheet, renderToBuffer } from "@react-pdf/renderer";
+
+export type SectionKpi = { label: string; value: string };
+export type SectionColumn = { header: string; width?: number; align?: "left" | "right" };
+
+export type SectionPdfData = {
+  shop: { name: string; timezone: string };
+  generatedAt: Date;
+  /** Section heading, e.g. "Dead stock". */
+  title: string;
+  /** One-line context, e.g. "No sales in 90 days · Class A". */
+  subtitle?: string;
+  /** Optional summary cards above the table. */
+  kpis?: SectionKpi[];
+  columns: SectionColumn[];
+  /** Row cells, already formatted to strings. */
+  rows: string[][];
+  /** Footnote line; falls back to a standard one. */
+  note?: string;
+  canSeeCosts?: boolean;
+};
+
+const DEFAULT_BRAND = "Wezesha Restock";
+const DEFAULT_TZ = "Africa/Nairobi";
+
+const INK = "#17171c";
+const MUTE = "#71717a";
+const LINE = "#e7e6ee";
+const TINT = "#faf8f4";
+
+/** Day/month/year in the shop's timezone. Intl avoids pulling in date-fns-tz. */
+const fmtDate = (d: Date, tz: string) =>
+  new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: tz,
+  }).format(d);
+
+const st = StyleSheet.create({
+  page: { padding: 40, fontSize: 10, color: INK, fontFamily: "Helvetica" },
+  row: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-end" },
+  brand: { fontSize: 16, fontFamily: "Helvetica-Bold", color: INK },
+  brandSub: { fontSize: 9, color: MUTE, marginTop: 2 },
+  title: { fontSize: 20, fontFamily: "Helvetica-Bold", textAlign: "right" },
+  meta: { fontSize: 9, color: MUTE, textAlign: "right", marginTop: 2 },
+  subtitle: { fontSize: 10, color: MUTE, marginTop: 14 },
+  kpiRow: { flexDirection: "row", marginTop: 16, gap: 10 },
+  kpi: { flex: 1, borderWidth: 1, borderColor: LINE, borderRadius: 6, padding: 12 },
+  kpiLabel: { fontSize: 8, color: MUTE, textTransform: "uppercase", letterSpacing: 1 },
+  kpiVal: { fontSize: 14, fontFamily: "Helvetica-Bold", marginTop: 4 },
+  tableWrap: { marginTop: 22 },
+  tableHead: { flexDirection: "row", borderBottomWidth: 1, borderBottomColor: INK, paddingBottom: 6 },
+  tableRow: { flexDirection: "row", borderBottomWidth: 1, borderBottomColor: LINE, paddingVertical: 6 },
+  tableRowAlt: { backgroundColor: TINT },
+  headCell: { fontSize: 8, color: MUTE, textTransform: "uppercase", letterSpacing: 0.5 },
+  footer: { position: "absolute", bottom: 30, left: 40, right: 40, fontSize: 8, color: MUTE, textAlign: "center" },
+});
+
+function ReportDocument({ data, brand }: { data: SectionPdfData; brand: string }) {
+  const tz = data.shop.timezone || DEFAULT_TZ;
+  const when = fmtDate(data.generatedAt, tz);
+  const cols = data.columns;
+  // Fixed widths default to the first column flexing (product name) and the rest fixed.
+  const cellStyle = (c: SectionColumn, i: number) => ({
+    ...(c.width ? { width: c.width } : { flex: i === 0 ? 1 : 0.5 }),
+    textAlign: (c.align ?? (i === 0 ? "left" : "right")) as "left" | "right",
+    paddingRight: 6,
+  });
+
+  return (
+    <Document title={`${data.title} — ${brand} report`}>
+      <Page size="A4" style={st.page}>
+        <View style={st.row}>
+          <View>
+            <Text style={st.brand}>{brand}</Text>
+            <Text style={st.brandSub}>{data.shop.name}</Text>
+          </View>
+          <View>
+            <Text style={st.title}>{data.title}</Text>
+            <Text style={st.meta}>Generated {when}</Text>
+          </View>
+        </View>
+
+        {data.subtitle ? <Text style={st.subtitle}>{data.subtitle}</Text> : null}
+
+        {data.kpis && data.kpis.length > 0 ? (
+          <View style={st.kpiRow}>
+            {data.kpis.map((k, i) => (
+              <View key={i} style={st.kpi}>
+                <Text style={st.kpiLabel}>{k.label}</Text>
+                <Text style={st.kpiVal}>{k.value}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        <View style={st.tableWrap}>
+          <View style={st.tableHead}>
+            {cols.map((c, i) => (
+              <Text key={i} style={[st.headCell, cellStyle(c, i)]}>{c.header}</Text>
+            ))}
+          </View>
+          {data.rows.length === 0 ? (
+            <Text style={{ color: MUTE, marginTop: 12 }}>Nothing to show for this selection.</Text>
+          ) : data.rows.map((r, ri) => (
+            <View key={ri} style={ri % 2 === 1 ? [st.tableRow, st.tableRowAlt] : st.tableRow} wrap={false}>
+              {cols.map((c, ci) => (
+                <Text key={ci} style={cellStyle(c, ci)}>{r[ci] ?? ""}</Text>
+              ))}
+            </View>
+          ))}
+        </View>
+
+        <Text style={st.footer} fixed>
+          {data.note ?? `${brand} · figures reflect the last-synced data`}
+          {data.canSeeCosts === false ? " · cost figures hidden for your role" : ""}
+        </Text>
+      </Page>
+    </Document>
+  );
+}
+
+export function renderSectionPdf(
+  data: SectionPdfData,
+  brand: string = DEFAULT_BRAND,
+): Promise<Buffer> {
+  return renderToBuffer(<ReportDocument data={data} brand={brand} />);
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-pdf/renderer": "^4.9.0",
     "@wezesha/db": "*",
     "@wezesha/forecast": "*",
     "@wezesha/forecast-run": "*",

--- a/apps/web/tests/member-visibility.test.tsx
+++ b/apps/web/tests/member-visibility.test.tsx
@@ -680,8 +680,8 @@ describe.skipIf(!runnable)("member cost-blindness on live screens (seeded db)", 
     // the test is that no OWNER-ONLY figure appears in the member's markup.
     const [ownerData, member, owner] = await Promise.all([
       getInsightsOverview(seeded.tenantId, { canViewCosts: true }),
-      ShelfHealth({ tenantId: seeded.tenantId, canViewCosts: false }).then(renderToStaticMarkup),
-      ShelfHealth({ tenantId: seeded.tenantId, canViewCosts: true }).then(renderToStaticMarkup),
+      ShelfHealth({ tenantId: seeded.tenantId, canViewCosts: false, currency: "KES" }).then(renderToStaticMarkup),
+      ShelfHealth({ tenantId: seeded.tenantId, canViewCosts: true, currency: "KES" }).then(renderToStaticMarkup),
     ]);
 
     const costFigures = [ownerData.cashTotalKes, ...ownerData.cashRows.map((r) => r.cashKes)]

--- a/apps/web/tests/today-counts-say-what-they-count.test.tsx
+++ b/apps/web/tests/today-counts-say-what-they-count.test.tsx
@@ -22,6 +22,7 @@ const table: DashboardTable = {
   deadCostKes: 1000,
   criticalCount: 4,
   capped: { stockout: false, reorder: false, onway: false, dead: false, all: false },
+  deadStockExport: [],
 };
 
 const html = () =>

--- a/apps/web/tests/transfers-sizing.test.ts
+++ b/apps/web/tests/transfers-sizing.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { destinationShares, sizeTransfers } from "../lib/data/transfers";
+// The pure sizing engine now lives in @wezesha/forecast (extracted so the
+// worker's owner report can share it). Import it directly — no DB env needed.
+import { destinationShares, sizeTransfers } from "@wezesha/forecast";
 
 /**
  * The transfer sizing engine, driven directly (it is pure, so no database is

--- a/apps/worker/src/crons.ts
+++ b/apps/worker/src/crons.ts
@@ -3,14 +3,16 @@ import type { Redis } from "ioredis";
 import { CUSTOMER_TENANTS_WHERE, prismaService } from "@wezesha/db";
 import { sendEmail, type SendEmail } from "./email";
 import { alertRecipients } from "./incident";
-import { buildWeeklySummary, renderWeeklySummary } from "./weekly-summary";
+import { buildOwnerReport } from "./owner-report";
+import { renderReportEmail } from "./owner-report-email";
 
 /**
- * Email cron scaffold. One repeatable dispatch job (BullMQ job scheduler, cron
- * pattern) fans out into one lightweight job per tenant, so a slow or failing
- * tenant summary never blocks the others and retries stay per-tenant.
- * Registration is env-gated in index.ts (EMAIL_CRONS=1) so dev and CI runs
- * stay quiet.
+ * Email cron scaffold. One repeatable dispatch job per cadence (BullMQ job
+ * scheduler, cron pattern) fans out into one lightweight job per tenant, so a
+ * slow or failing tenant report never blocks the others and retries stay
+ * per-tenant. Two cadences share this one queue: the weekly summary and the
+ * monthly owner report. Registration is env-gated in index.ts (EMAIL_CRONS=1)
+ * so dev and CI runs stay quiet.
  */
 
 export const EMAIL_CRON_QUEUE = "email-crons";
@@ -21,6 +23,13 @@ export const WEEKLY_SUMMARY_PATTERN = "0 6 * * 1";
 export const DISPATCH_JOB = "weekly-summary-dispatch";
 export const TENANT_JOB = "weekly-summary-tenant";
 
+export const MONTHLY_REPORT_SCHEDULER = "monthly-report";
+/** 1st of the month, 06:00 worker-local time. */
+export const MONTHLY_REPORT_PATTERN = "0 6 1 * *";
+
+export const MONTHLY_DISPATCH_JOB = "monthly-report-dispatch";
+export const MONTHLY_TENANT_JOB = "monthly-report-tenant";
+
 export type EmailCronJobData = { tenantId?: string };
 export type EmailCronQueue = Queue<EmailCronJobData>;
 
@@ -28,18 +37,25 @@ export function createEmailCronQueue(connection: Redis): EmailCronQueue {
   return new Queue<EmailCronJobData>(EMAIL_CRON_QUEUE, { connection });
 }
 
-/** Idempotent: upserting the scheduler replaces any previous cadence. */
+/** Idempotent: upserting each scheduler replaces any previous cadence. Both the
+ *  weekly and monthly cadences live on this one queue. */
 export async function registerEmailCronSchedules(queue: EmailCronQueue): Promise<void> {
   await queue.upsertJobScheduler(
     WEEKLY_SUMMARY_SCHEDULER,
     { pattern: WEEKLY_SUMMARY_PATTERN },
     { name: DISPATCH_JOB }
   );
+  await queue.upsertJobScheduler(
+    MONTHLY_REPORT_SCHEDULER,
+    { pattern: MONTHLY_REPORT_PATTERN },
+    { name: MONTHLY_DISPATCH_JOB }
+  );
 }
 
-/** Fan the dispatch out into one job per tenant. Returns the tenant count.
- *  Tenant enumeration is a cross-tenant system read — prismaService. */
-export async function dispatchWeeklySummaries(queue: EmailCronQueue): Promise<number> {
+/** Fan a dispatch out into one job per tenant, under the given per-tenant job
+ *  name. Returns the tenant count. Tenant enumeration is a cross-tenant system
+ *  read — prismaService. */
+async function fanOutToTenants(queue: EmailCronQueue, jobName: string): Promise<number> {
   // eslint-disable-next-line tenant-safety/require-tenant-scope -- fan-out dispatch: enumerating every customer workspace is the job, and the per-tenant work it queues is scoped.
   const tenants = await prismaService.tenant.findMany({
     where: CUSTOMER_TENANTS_WHERE,
@@ -47,35 +63,61 @@ export async function dispatchWeeklySummaries(queue: EmailCronQueue): Promise<nu
   });
   if (tenants.length > 0) {
     await queue.addBulk(
-      tenants.map((tenant) => ({ name: TENANT_JOB, data: { tenantId: tenant.id } }))
+      tenants.map((tenant) => ({ name: jobName, data: { tenantId: tenant.id } }))
     );
   }
   return tenants.length;
 }
 
-/** Build, render, and send one tenant's summary. False = nothing sent (tenant
- *  gone, nothing to say, or nobody left who wants it). */
+/** Fan the weekly dispatch out into one job per tenant. Returns the tenant count. */
+export async function dispatchWeeklySummaries(queue: EmailCronQueue): Promise<number> {
+  return fanOutToTenants(queue, TENANT_JOB);
+}
+
+/** Fan the monthly dispatch out into one job per tenant. Returns the tenant count. */
+export async function dispatchMonthlyReports(queue: EmailCronQueue): Promise<number> {
+  return fanOutToTenants(queue, MONTHLY_TENANT_JOB);
+}
+
+/** Build, render, and send one tenant's owner report at the given cadence.
+ *  False = nothing sent (tenant gone, nothing to say, or nobody left who wants
+ *  it). The weekly and monthly paths share this — same rich trend body, they
+ *  differ only in granularity, the opt-out kind, and the recipient preference. */
+async function sendOwnerReport(
+  tenantId: string,
+  granularity: "week" | "month",
+  kind: "weekly_summary" | "monthly_report",
+  send: SendEmail
+): Promise<boolean> {
+  const recipients = await alertRecipients(tenantId, kind);
+  if (!recipients) return false;
+  const report = await buildOwnerReport(tenantId, granularity);
+  if (!report) return false;
+  // One copy each, in series: the same body, addressed to whoever still wants
+  // it. Built once — the report is the workspace's, not the reader's.
+  const { subject, text, html } = renderReportEmail(report);
+  for (const to of recipients.emails) {
+    await send({ to, subject, text, html, tenantId, kind });
+  }
+  return true;
+}
+
+/** Build, render, and send one tenant's weekly report (the rich week-by-week
+ *  trend). False = nothing sent. */
 export async function sendWeeklySummary(
   tenantId: string,
   send: SendEmail = sendEmail
 ): Promise<boolean> {
-  const recipients = await alertRecipients(tenantId, "weekly_summary");
-  if (!recipients) return false;
-  const summary = await buildWeeklySummary(tenantId);
-  if (!summary) return false;
-  // One copy each, in series: the same body, addressed to whoever still wants
-  // it. Built once — the summary is the workspace's, not the reader's.
-  const body = renderWeeklySummary(summary);
-  for (const to of recipients.emails) {
-    await send({
-      to,
-      subject: `Weekly stock summary — ${summary.tenantName}`,
-      text: body,
-      tenantId,
-      kind: "weekly_summary",
-    });
-  }
-  return true;
+  return sendOwnerReport(tenantId, "week", "weekly_summary", send);
+}
+
+/** Build, render, and send one tenant's monthly owner report (month-by-month
+ *  trend). False = nothing sent. */
+export async function sendMonthlyReport(
+  tenantId: string,
+  send: SendEmail = sendEmail
+): Promise<boolean> {
+  return sendOwnerReport(tenantId, "month", "monthly_report", send);
 }
 
 export interface EmailCronWorkerOptions {
@@ -94,8 +136,16 @@ export function createEmailCronWorker(options: EmailCronWorkerOptions): Worker<E
         await dispatchWeeklySummaries(options.queue);
         return;
       }
+      if (job.name === MONTHLY_DISPATCH_JOB) {
+        await dispatchMonthlyReports(options.queue);
+        return;
+      }
       if (job.name === TENANT_JOB && job.data.tenantId) {
         await sendWeeklySummary(job.data.tenantId, options.send);
+        return;
+      }
+      if (job.name === MONTHLY_TENANT_JOB && job.data.tenantId) {
+        await sendMonthlyReport(job.data.tenantId, options.send);
       }
     },
     { connection: options.connection }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -68,7 +68,8 @@ import { createSyncWorker } from "./worker";
  *   EMAIL_FROM            — outbound sender ("Name <address>" or bare address);
  *                           required once RESEND_API_KEY is set
  *   EMAIL_CRONS           — "1" registers + runs the email cron schedules
- *                           (weekly summaries); unset keeps dev/CI quiet
+ *                           (weekly summaries + monthly owner reports); unset
+ *                           keeps dev/CI quiet
  *   OPS_CRONS             — "1" registers + runs the ops cron schedules
  *                           (daily plan-limit checks); unset keeps dev/CI quiet
  *   POS_CRONS             — "1" registers + runs the POS cron schedules
@@ -133,7 +134,7 @@ async function main(): Promise<void> {
       console.error(`worker: cron ${job?.id} failed`, err);
       captureError(err, { tenantId: job?.data?.tenantId, jobId: job?.id, queue: "email-crons" });
     });
-    console.log("worker: email crons registered (weekly summary)");
+    console.log("worker: email crons registered (weekly summary + monthly report)");
   }
 
   let opsQueue: OpsCronQueue | null = null;

--- a/apps/worker/src/owner-report-email.ts
+++ b/apps/worker/src/owner-report-email.ts
@@ -1,0 +1,182 @@
+import type { OwnerReport, TrendRow, AttentionLine } from "./owner-report";
+
+/**
+ * Render an OwnerReport into a branded HTML email — a WEEK-BY-WEEK (or monthly)
+ * health trend table (no buttons), a one-line "are we improving?" read, a short
+ * bestsellers-stocked-out list, the restock buy-list, and any warehouse→branch
+ * transfers. Plain-text fallback included.
+ *
+ * Ported from the reference app's lib/reports/report-email.ts. Brand strings are
+ * parameterised (default "Wezesha Restock"); money uses the tenant's own
+ * currency rather than a hardcoded KES.
+ */
+
+const DEFAULT_BRAND = "Wezesha Restock";
+
+/** Short money: the tenant's currency code + a k/M-abbreviated amount. */
+function money(cur: string, n: number): string {
+  const a = Math.abs(n);
+  const short =
+    a >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M`
+    : a >= 1_000 ? `${Math.round(n / 1_000)}k`
+    : `${Math.round(n)}`;
+  return `${cur} ${short}`;
+}
+const pct = (n: number | null) => (n == null ? "—" : `${n}%`);
+
+const abcChip = (abc: AttentionLine["abc"]) => {
+  const cls = abc ?? "C";
+  const bg = cls === "A" ? "#db5586" : cls === "B" ? "#f2d0dd" : "#eee";
+  const fg = cls === "A" ? "#fff" : cls === "B" ? "#a62f5c" : "#888";
+  return `<span style="display:inline-block;width:18px;height:18px;line-height:18px;text-align:center;border-radius:5px;background:${bg};color:${fg};font-size:11px;font-weight:700">${cls}</span>`;
+};
+
+/** Neutral one-line summary of the latest period vs the one before — states the
+ *  numbers, no "improving/worsening" verdict (owner reads the trend themselves). */
+function improvementLine(trend: TrendRow[], unit: string): string {
+  const withData = trend.filter((t) => t.stockoutPct != null);
+  if (withData.length < 2) return `Bestseller stockout rate this ${unit}: ${withData[0]?.stockoutPct ?? "—"}%.`;
+  const now = withData[0]!.stockoutPct!;
+  const prev = withData[1]!.stockoutPct!;
+  const colour = now > prev ? "#c0392b" : now < prev ? "#2f8a4c" : "#666";
+  return `Bestseller stockout rate: <span style="color:${colour};font-weight:600">${now}%</span> this ${unit} (last ${unit}: ${prev}%).`;
+}
+
+function trendTable(cur: string, trend: TrendRow[], unit: string): string {
+  const th = (t: string, right = true) => `<th style="text-align:${right ? "right" : "left"};font-size:10px;color:#aaa;text-transform:uppercase;letter-spacing:.3px;padding:6px 5px;border-bottom:2px solid #333">${t}</th>`;
+  const td = (t: string, right = true, bold = false, colour = "#333") => `<td style="text-align:${right ? "right" : "left"};font-size:13px;padding:7px 5px;border-bottom:1px solid #eee;color:${colour}${bold ? ";font-weight:700" : ""}">${t}</td>`;
+  const rows = trend.map((r, i) => {
+    const flag = r.partial ? ` <span style="color:#b8791a;font-size:10px">partial</span>` : r.inferred ? ` <span style="color:#999;font-size:10px">est.</span>` : "";
+    const soColour = r.stockoutPct == null ? "#999" : r.stockoutPct >= 15 ? "#c0392b" : r.stockoutPct <= 8 ? "#2f8a4c" : "#333";
+    return `<tr${i === 0 ? ' style="background:#faf5f7"' : ""}>
+      ${td(`<b>${r.label}</b>${flag}`, false)}
+      ${td(money(cur, r.salesKes))}
+      ${td(`${r.stockoutA}`, true, i === 0, r.stockoutA > 0 ? "#c0392b" : "#999")}
+      ${td(`${r.stockoutB}`)}
+      ${td(pct(r.stockoutPct), true, i === 0, soColour)}
+      ${td(`${r.deadCount} · ${money(cur, r.deadValueKes)}`)}
+      ${td(money(cur, r.missedRevenueKes))}
+    </tr>`;
+  }).join("");
+  return `<table style="width:100%;border-collapse:collapse;margin-top:6px">
+    <tr>${th(unit === "week" ? "Week" : "Month", false)}${th("Sales")}${th("Out A")}${th("Out B")}${th("Out %")}${th("Dead (#·" + cur + ")")}${th("Rev. missed")}</tr>
+    ${rows}
+  </table>
+  <p style="color:#aaa;font-size:11px;margin:8px 0 0"><b>Out A / Out B</b> = Class-A / Class-B bestsellers that ran to zero · <b>Out %</b> = A/B stockout rate · <b>Dead</b> = held items with no sales + capital frozen · <b>Rev. missed</b> = est. sales lost while out of stock. Newest ${unit} highlighted.</p>`;
+}
+
+/** "What to restock next period" — the buy list + budget. */
+function restockTable(cur: string, r: OwnerReport, unit: string): string {
+  const budget = money(cur, r.restockBudgetKes);
+  const header = `<h3 style="font-size:14px;margin:28px 0 4px">🛒 Restock next ${unit} — ${r.restockCount} item${r.restockCount === 1 ? "" : "s"} · budget ${budget}</h3>`;
+  if (r.restock.length === 0) return `${header}<p style="color:#2f8a4c;font-size:13px;margin:4px 0 0">Nothing urgent to restock — you're well covered.</p>`;
+  const rows = r.restock.map((l) => `<tr>
+    <td style="padding:6px 4px;font-size:13px">${abcChip(l.abc)} ${l.title}</td>
+    <td style="padding:6px 4px;font-size:13px;text-align:right;font-weight:600;white-space:nowrap">${l.qty}</td>
+    <td style="padding:6px 4px;font-size:13px;text-align:right;white-space:nowrap;color:#666">${money(cur, l.costKes)}</td>
+    <td style="padding:6px 4px;font-size:12px;text-align:right;white-space:nowrap;color:${l.daysLeft <= 0 ? "#c0392b" : "#888"}">${l.daysLeft}d left</td>
+  </tr>`).join("");
+  const more = r.restockCount > r.restock.length ? `<p style="color:#aaa;font-size:11px;margin:6px 0 0">Showing the top ${r.restock.length} by urgency · ${r.restockCount - r.restock.length} more in the Restock planner. <b>Budget ${budget} covers all ${r.restockCount} items.</b></p>` : "";
+  return `${header}
+  <p style="color:#666;font-size:12px;margin:2px 0 6px">Order these from your suppliers by next ${unit} — quantities already account for stock on hand and what's on the way.</p>
+  <table style="width:100%;border-collapse:collapse;margin-top:4px">
+    <tr><th style="text-align:left;font-size:10px;color:#aaa;text-transform:uppercase;padding:4px">Product</th><th style="text-align:right;font-size:10px;color:#aaa;text-transform:uppercase;padding:4px">Order</th><th style="text-align:right;font-size:10px;color:#aaa;text-transform:uppercase;padding:4px">Cost</th><th style="text-align:right;font-size:10px;color:#aaa;text-transform:uppercase;padding:4px">Runway</th></tr>
+    ${rows}
+  </table>${more}`;
+}
+
+/** "Distribute from the warehouse" — transfers to the branches. */
+function transferTable(r: OwnerReport): string {
+  if (r.transferCount === 0) return "";
+  const header = `<h3 style="font-size:14px;margin:28px 0 4px">🚚 Distribute from ${r.transferFrom || "the warehouse"} — ${r.transferCount} transfer${r.transferCount === 1 ? "" : "s"}</h3>`;
+  const rows = r.transfers.map((l) => `<tr>
+    <td style="padding:6px 4px;font-size:13px">${abcChip(l.abc)} ${l.title}</td>
+    <td style="padding:6px 4px;font-size:13px;text-align:right;font-weight:600;white-space:nowrap">${l.qty}</td>
+    <td style="padding:6px 4px;font-size:12px;color:#666;text-align:right;white-space:nowrap">→ ${l.toBranch}</td>
+  </tr>`).join("");
+  const more = r.transferCount > r.transfers.length ? `<p style="color:#aaa;font-size:11px;margin:6px 0 0">Showing the top ${r.transfers.length} · ${r.transferCount - r.transfers.length} more in Distribution. Move stock you already own to the branches that need it (no new purchase).</p>` : `<p style="color:#aaa;font-size:11px;margin:6px 0 0">Move stock you already own to the branches that need it — no new purchase.</p>`;
+  return `${header}
+  <table style="width:100%;border-collapse:collapse;margin-top:4px">
+    <tr><th style="text-align:left;font-size:10px;color:#aaa;text-transform:uppercase;padding:4px">Product</th><th style="text-align:right;font-size:10px;color:#aaa;text-transform:uppercase;padding:4px">Move</th><th style="text-align:right;font-size:10px;color:#aaa;text-transform:uppercase;padding:4px">To branch</th></tr>
+    ${rows}
+  </table>${more}`;
+}
+
+function attentionList(lines: AttentionLine[]): string {
+  if (lines.length === 0) return `<p style="color:#2f8a4c;font-size:13px;margin:0">No bestsellers stocked out right now — nicely covered.</p>`;
+  const rows = lines.map((l) => `<tr>
+    <td style="padding:6px 4px;font-size:13px">${abcChip(l.abc)} ${l.title}</td>
+    <td style="padding:6px 4px;font-size:13px;text-align:right;font-weight:600;white-space:nowrap">${l.onHand} on hand</td>
+    <td style="padding:6px 4px;font-size:12px;color:${l.enRoute > 0 ? "#2f8a4c" : "#c0392b"};text-align:right;white-space:nowrap">${l.enRoute > 0 ? `${l.enRoute} en route` : "nothing coming"}</td>
+  </tr>`).join("");
+  return `<table style="width:100%;border-collapse:collapse">${rows}</table>`;
+}
+
+export function renderReportEmail(
+  r: OwnerReport,
+  brand: string = DEFAULT_BRAND,
+): { subject: string; html: string; text: string } {
+  const unit = r.granularity === "week" ? "week" : "month";
+  const periodWord = r.granularity === "week" ? "Weekly" : "Monthly";
+  const cur = r.currency || "KES";
+  const initial = brand.trim().charAt(0).toUpperCase() || "W";
+  const subject = `${periodWord} report — ${r.tenantName} · ${r.latestLabel}`;
+
+  const html = `<div style="font-family:sans-serif;max-width:640px;margin:0 auto;padding:32px 24px;color:#1a1a1a">
+  <div style="margin-bottom:18px">
+    <span style="display:inline-block;width:34px;height:34px;border-radius:9px;background:linear-gradient(135deg,#db5586,#a62f5c);color:#fff;font-weight:700;font-size:15px;text-align:center;line-height:34px">${initial}</span>
+    <span style="margin-left:10px;font-weight:600;font-size:15px">${brand}</span>
+  </div>
+  <div style="font-size:11px;color:#aaa;text-transform:uppercase;letter-spacing:.5px">${periodWord} report · ${r.tenantName}</div>
+  <h1 style="font-size:22px;font-weight:700;margin:2px 0 10px">How your shop is trending</h1>
+  <p style="font-size:14px;line-height:1.5;margin:0 0 4px">${improvementLine(r.trend, unit)}</p>
+
+  <h3 style="font-size:14px;margin:26px 0 4px">Last ${r.trend.length} ${unit}s</h3>
+  ${trendTable(cur, r.trend, unit)}
+
+  <h3 style="font-size:14px;margin:28px 0 8px">🔴 Bestsellers stocked out now</h3>
+  ${attentionList(r.needsAttention)}
+
+  ${restockTable(cur, r, unit)}
+
+  ${transferTable(r)}
+
+  <hr style="border:none;border-top:1px solid #eee;margin:30px 0 16px"/>
+  <p style="color:#bbb;font-size:11px;margin:0">Coming from ${brand} · you're receiving this as an owner/admin of ${r.tenantName}.</p>
+</div>`;
+
+  // Plain-text fallback — the same trend as an aligned table.
+  const col = (s: string | number, w: number) => String(s).padEnd(w).slice(0, w);
+  const head = `${col(unit === "week" ? "Week" : "Month", 9)} ${col("Sales", 10)} ${col("OutA", 5)} ${col("OutB", 5)} ${col("Out%", 6)} ${col("Dead", 14)} Missed`;
+  const trendLines = r.trend.map((t) => `${col(t.label, 9)} ${col(money(cur, t.salesKes), 10)} ${col(t.stockoutA, 5)} ${col(t.stockoutB, 5)} ${col(pct(t.stockoutPct), 6)} ${col(t.deadCount + "·" + money(cur, t.deadValueKes), 14)} ${money(cur, t.missedRevenueKes)}`);
+  const text = [
+    `${periodWord} report — ${r.tenantName} · ${r.latestLabel}`,
+    ``,
+    improvementLine(r.trend, unit).replace(/<[^>]+>/g, ""),
+    ``,
+    `LAST ${r.trend.length} ${unit.toUpperCase()}S`,
+    head,
+    ...trendLines,
+    ``,
+    `BESTSELLERS STOCKED OUT NOW`,
+    r.needsAttention.length
+      ? r.needsAttention.map((l) => `  [${l.abc ?? "C"}] ${l.title} — ${l.onHand} on hand, ${l.enRoute > 0 ? `${l.enRoute} en route` : "nothing coming"}`).join("\n")
+      : "  none — nicely covered.",
+    ``,
+    `RESTOCK NEXT ${unit.toUpperCase()} (order from suppliers) — ${r.restockCount} items · budget ${money(cur, r.restockBudgetKes)}`,
+    r.restock.length
+      ? r.restock.map((l) => `  [${l.abc ?? "C"}] ${l.title} — order ${l.qty} (${money(cur, l.costKes)}, ${l.daysLeft}d left)`).join("\n")
+      : "  nothing urgent.",
+    ``,
+    ...(r.transferCount > 0
+      ? [
+          `DISTRIBUTE FROM ${r.transferFrom.toUpperCase()} — ${r.transferCount} transfers (move stock you own, no purchase)`,
+          r.transfers.map((l) => `  [${l.abc ?? "C"}] ${l.title} — move ${l.qty} → ${l.toBranch}`).join("\n"),
+          ``,
+        ]
+      : []),
+    `Coming from ${brand}`,
+  ].join("\n");
+
+  return { subject, html, text };
+}

--- a/apps/worker/src/owner-report.ts
+++ b/apps/worker/src/owner-report.ts
@@ -1,0 +1,647 @@
+import { prismaService, roleOf } from "@wezesha/db";
+import { sizeTransfers, destinationShares, type DestinationPosition } from "@wezesha/forecast";
+
+/**
+ * Owner report — a WEEK-BY-WEEK (or month-by-month) health TREND ("am I
+ * improving?"). Rows = periods (last 6 weeks / 6 months), columns = the health
+ * metrics; plus a short "needs attention" list (bestsellers currently stocked
+ * out), a restock buy-list with budget, and warehouse→branch transfers.
+ *
+ * Ported from the reference app's lib/reports/weekly-report.ts. The reference
+ * leaned on shared app-side helpers (stockHealthByPeriod, latestForecastRunId,
+ * getDeadStockWindowDays). Those are apps/web-only, so the pure ones are inlined
+ * here. The transfers section uses the shared pure sizing engine now extracted
+ * into @wezesha/forecast (sizeTransfers/destinationShares), so it proposes the
+ * same warehouse→branch moves the distribution page would.
+ *
+ * Queries run on prismaService WITH an explicit tenantId filter on every
+ * where-clause and every raw query — the cron fires with no session and no
+ * request, so there is no tenant context to scope a client with; that system
+ * path is the documented use of the BYPASSRLS connection (same pattern as
+ * weekly-summary.ts).
+ */
+
+export type ReportGranularity = "week" | "month";
+
+/** One period's health row in the trend table. */
+export type TrendRow = {
+  label: string;          // "Aug 4" (week start) / "Jul 2026"
+  salesKes: number;
+  stockoutA: number;      // Class-A bestsellers that ran to zero
+  stockoutB: number;      // Class-B
+  stockoutPct: number | null; // A/B stockout rate overall
+  overstockCount: number | null;
+  deadCount: number;
+  deadValueKes: number;   // capital frozen in dead stock
+  missedRevenueKes: number;
+  partial: boolean;
+  inferred: boolean;
+};
+
+export type AttentionLine = {
+  title: string; sku: string; abc: "A" | "B" | "C" | null; onHand: number; enRoute: number;
+};
+
+/** A line in "what to restock next period". */
+export type RestockLine = {
+  title: string; sku: string; abc: "A" | "B" | "C" | null;
+  qty: number; costKes: number; daysLeft: number;
+};
+
+/** A warehouse→branch transfer suggestion. */
+export type TransferLine = {
+  title: string; abc: "A" | "B" | "C" | null; qty: number; toBranch: string;
+};
+
+export type OwnerReport = {
+  tenantName: string;
+  currency: string;
+  granularity: ReportGranularity;
+  latestLabel: string;
+  trend: TrendRow[];         // newest first
+  needsAttention: AttentionLine[];
+  restock: RestockLine[];    // top items to reorder next period
+  restockBudgetKes: number;  // total cost of the full restock
+  restockCount: number;      // total number of items to restock
+  transfers: TransferLine[]; // top warehouse→branch moves
+  transferCount: number;     // total transfer lines
+  transferFrom: string;      // source warehouse name
+  hasData: boolean;
+};
+
+// ── Period math (inlined from lib/metrics/stock-health, the pure bits) ─────────
+
+const DAY = 86_400_000;
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/** ISO-8601 week key, identical to Postgres to_char(date, 'IYYY-"W"IW'). */
+function isoWeekKey(d: Date): string {
+  const t = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = t.getUTCDay() || 7; // Mon=1..Sun=7
+  t.setUTCDate(t.getUTCDate() + 4 - day); // the Thursday decides the ISO year
+  const isoYear = t.getUTCFullYear();
+  const jan1 = new Date(Date.UTC(isoYear, 0, 1));
+  const week = Math.ceil(((t.getTime() - jan1.getTime()) / DAY + 1) / 7);
+  return `${isoYear}-W${pad(week)}`;
+}
+
+const monthKey = (d: Date) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}`;
+
+function daysInPeriod(period: string, granularity: ReportGranularity): number {
+  if (granularity === "week") return 7;
+  const parts = period.split("-").map(Number);
+  const y = parts[0] ?? 0, m = parts[1] ?? 1;
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+/** UTC start of a period key. Week keys start on their ISO Monday. */
+function periodStartDate(period: string, granularity: ReportGranularity): Date {
+  if (granularity === "month") {
+    const parts = period.split("-").map(Number);
+    const y = parts[0] ?? 0, m = parts[1] ?? 1;
+    return new Date(Date.UTC(y, m - 1, 1));
+  }
+  const parts = period.split("-W").map(Number);
+  const isoYear = parts[0] ?? 0, wk = parts[1] ?? 1;
+  // Jan 4 is always in ISO week 1; back up to that week's Monday, then step.
+  const jan4 = new Date(Date.UTC(isoYear, 0, 4));
+  const monday = new Date(jan4);
+  monday.setUTCDate(jan4.getUTCDate() - ((jan4.getUTCDay() || 7) - 1));
+  monday.setUTCDate(monday.getUTCDate() + (wk - 1) * 7);
+  return monday;
+}
+
+/** The last `count` COMPLETED period keys, ascending (current period excluded). */
+function completedPeriods(now: Date, granularity: ReportGranularity, count: number): string[] {
+  const out: string[] = [];
+  if (granularity === "month") {
+    const y = now.getUTCFullYear(), m = now.getUTCMonth();
+    for (let i = count; i >= 1; i--) out.push(monthKey(new Date(Date.UTC(y, m - i, 1))));
+    return out;
+  }
+  const monday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  monday.setUTCDate(monday.getUTCDate() - ((monday.getUTCDay() || 7) - 1));
+  for (let i = count; i >= 1; i--) {
+    const d = new Date(monday);
+    d.setUTCDate(d.getUTCDate() - 7 * i);
+    out.push(isoWeekKey(d));
+  }
+  return out;
+}
+
+/** The week keys covering the trailing `windowDays` ending at `period` — so the
+ *  weekly dead-stock test uses the tenant's configurable dead-stock window. */
+function trailingWeekKeys(period: string, windowDays: number): Set<string> {
+  const start = periodStartDate(period, "week");
+  const buckets = Math.max(1, Math.ceil(windowDays / 7));
+  const keys = new Set<string>();
+  for (let i = 0; i < buckets; i++) {
+    const d = new Date(start);
+    d.setUTCDate(d.getUTCDate() - 7 * i);
+    keys.add(isoWeekKey(d));
+  }
+  return keys;
+}
+
+function labelFor(period: string, periodStart: Date): string {
+  if (period.includes("W")) return `${MONTHS[periodStart.getUTCMonth()]} ${periodStart.getUTCDate()}`;
+  const parts = period.split("-").map(Number);
+  const y = parts[0] ?? 0, m = parts[1] ?? 1;
+  return `${MONTHS[m - 1]} ${y}`;
+}
+
+// ── Inlined helpers the worker cannot import from apps/web ─────────────────────
+
+/** Code default dead-stock lookback — mirrors apps/web DEFAULT_DEAD_STOCK_DAYS
+ *  so "dead" means the same everywhere. */
+const DEFAULT_DEAD_STOCK_DAYS = 90;
+
+/** Dead-stock lookback window (days), clamped 30–365. Reads
+ *  TenantConfig.deadStockWindowDays (mirrors apps/web tenant config). */
+async function getDeadStockWindowDays(tenantId: string): Promise<number> {
+   
+  const cfg = await prismaService.tenantConfig.findUnique({
+    where: { tenantId },
+    select: { deadStockWindowDays: true },
+  });
+  const v = cfg?.deadStockWindowDays ?? DEFAULT_DEAD_STOCK_DAYS;
+  return Math.max(30, Math.min(365, v));
+}
+
+/** Regimes only the Python sidecar emits — their presence marks an AI run. */
+const AI_REGIMES = ["sarima", "tsb", "cold_start"];
+
+/** Choose the winning run id from same-day candidates: AI run → most complete →
+ *  id (stable). Ported from apps/web latest-run resolution. */
+function pickBestRun(runs: { forecastRunId: string; count: number }[], aiRunIds: Set<string>): string | null {
+  if (runs.length === 0) return null;
+  const sorted = [...runs].sort((a, b) => {
+    const aAi = aiRunIds.has(a.forecastRunId) ? 1 : 0;
+    const bAi = aiRunIds.has(b.forecastRunId) ? 1 : 0;
+    if (aAi !== bAi) return bAi - aAi; // AI run wins
+    if (b.count !== a.count) return b.count - a.count; // then most complete
+    return a.forecastRunId.localeCompare(b.forecastRunId); // stable
+  });
+  return sorted[0]?.forecastRunId ?? null;
+}
+
+/** The latest, most trustworthy forecast run for a tenant (same rule the app
+ *  uses: latest runDate → AI engine → most complete → id). null when none. */
+async function latestForecastRunId(tenantId: string): Promise<string | null> {
+   
+  const latest = await prismaService.prediction.findFirst({
+    where: { tenantId },
+    orderBy: { runDate: "desc" },
+    select: { runDate: true },
+  });
+  if (!latest) return null;
+   
+  const runs = await prismaService.prediction.groupBy({
+    by: ["forecastRunId"],
+    where: { tenantId, runDate: latest.runDate },
+    _count: { _all: true },
+  });
+  if (runs.length === 0) return null;
+   
+  const aiRuns = await prismaService.prediction.groupBy({
+    by: ["forecastRunId"],
+    where: { tenantId, runDate: latest.runDate, regime: { in: AI_REGIMES } },
+  });
+  const aiRunIds = new Set(aiRuns.map((r) => r.forecastRunId));
+  return pickBestRun(
+    runs.map((r) => ({ forecastRunId: r.forecastRunId, count: r._count._all })),
+    aiRunIds
+  );
+}
+
+// ── Trend engine (inlined + trimmed from stockHealthByPeriod) ─────────────────
+
+type SnapRow = { period: string; pid: string; minOh: number; endOh: number; daysOut: number };
+type SaleRow = { period: string; pid: string; qty: number };
+type ProductMeta = { abc: string | null; costKes: number; priceKes: number };
+
+/** Per-period roll-up: A/B stockout split + rate, dead count/value, overstock
+ *  count, missed revenue. Mirrors the reference stockHealthByPeriod, keeping the
+ *  same stockout / dead-stock / inferred-pre-snapshot rules but only computing
+ *  the numbers this report renders. Pure. */
+type PeriodHealth = {
+  period: string;
+  stockoutA: number;
+  stockoutB: number;
+  stockoutPct: number | null;
+  overstockCount: number | null;
+  deadStockCount: number;
+  deadStockValueKes: number;
+  missedRevenueKes: number;
+  stockoutInferred: boolean;
+};
+
+const OVERSTOCK_THRESHOLD_DAYS = 90;
+
+function stockHealthByPeriod(input: {
+  periods: string[];
+  granularity: ReportGranularity;
+  snaps: SnapRow[];
+  /** May include periods BEFORE periods[0] — needed for the weekly trailing window. */
+  sales: SaleRow[];
+  products: Map<string, ProductMeta>;
+  deadStockWindowDays: number;
+}): PeriodHealth[] {
+  const { periods, granularity, snaps, sales, products, deadStockWindowDays } = input;
+
+  const soldQty = new Map<string, number>(); // "period:pid" -> qty
+  const soldPeriodsByPid = new Map<string, Set<string>>();
+  for (const s of sales) {
+    if (s.qty <= 0) continue;
+    const k = `${s.period}:${s.pid}`;
+    soldQty.set(k, (soldQty.get(k) ?? 0) + s.qty);
+    let set = soldPeriodsByPid.get(s.pid);
+    if (!set) soldPeriodsByPid.set(s.pid, (set = new Set()));
+    set.add(s.period);
+  }
+  const snapsByPeriod = new Map<string, SnapRow[]>();
+  for (const r of snaps) {
+    const arr = snapsByPeriod.get(r.period);
+    if (arr) arr.push(r);
+    else snapsByPeriod.set(r.period, [r]);
+  }
+  // Period keys are zero-padded, so lexicographic <= is chronological.
+  const soldEverBy = (pid: string, p: string) => {
+    const set = soldPeriodsByPid.get(pid);
+    if (!set) return false;
+    for (const sp of set) if (sp <= p) return true;
+    return false;
+  };
+
+  return periods.map((p) => {
+    const days = daysInPeriod(p, granularity);
+    const psnaps = snapsByPeriod.get(p);
+    const deadTrailing = granularity === "week" ? trailingWeekKeys(p, deadStockWindowDays) : null;
+    const trailing = granularity === "week" ? trailingWeekKeys(p, 21) : null;
+
+    let stockoutA = 0, stockoutB = 0, abSkuCount = 0, stockoutCount = 0;
+    let deadCount = 0, deadValue = 0, overstockCount = 0, missedRevenue = 0;
+
+    for (const r of psnaps ?? []) {
+      const meta = products.get(r.pid);
+      if (!meta) continue;
+      const sold = soldQty.get(`${p}:${r.pid}`) ?? 0;
+      const isAB = meta.abc === "A" || meta.abc === "B";
+      if (isAB) abSkuCount++;
+
+      const stockedOut = isAB && r.minOh <= 0 && sold > 0;
+      if (stockedOut) {
+        stockoutCount++;
+        if (meta.abc === "A") stockoutA++;
+        else stockoutB++;
+        // Missed revenue: run-rate over observed days × days at zero × price.
+        const daysOut = Math.min(r.daysOut, days);
+        const daysSelling = Math.max(1, days - daysOut);
+        const runRate = sold / daysSelling;
+        const missed = Math.round(runRate * daysOut * meta.priceKes);
+        if (missed > 0) missedRevenue += missed;
+      }
+
+      if (r.endOh > 0 && soldEverBy(r.pid, p)) {
+        const quiet = deadTrailing
+          ? ![...deadTrailing].some((w) => (soldQty.get(`${w}:${r.pid}`) ?? 0) > 0)
+          : sold === 0;
+        if (quiet) {
+          deadCount++;
+          deadValue += r.endOh * meta.costKes;
+        }
+      }
+
+      // Overstock: cover-days at period end beyond threshold, at the period's own
+      // pace. Zero run-rate is dead stock, not overstock.
+      const dailyRate = sold / days;
+      if (dailyRate > 0) {
+        const coverDays = r.endOh / dailyRate;
+        if (coverDays > OVERSTOCK_THRESHOLD_DAYS) overstockCount++;
+      }
+    }
+
+    // Inferred stockouts for periods with NO snapshot history: an A/B product that
+    // sold in a trailing week but had ZERO sales this period is a proven seller
+    // gone silent — the classic censoring signal for "went out of stock".
+    let inferredStockoutA = 0, inferredStockoutB = 0, inferredAbBase = 0;
+    if (!psnaps && trailing) {
+      const seen = new Set<string>();
+      for (const [pid] of soldPeriodsByPid) {
+        const meta = products.get(pid);
+        if (!meta || !(meta.abc === "A" || meta.abc === "B")) continue;
+        if (soldEverBy(pid, p)) inferredAbBase++;
+        if (seen.has(pid)) continue;
+        const soldThis = (soldQty.get(`${p}:${pid}`) ?? 0) > 0;
+        if (soldThis) continue;
+        const wasSelling = [...trailing].some((w) => (soldQty.get(`${w}:${pid}`) ?? 0) > 0);
+        if (wasSelling) {
+          seen.add(pid);
+          if (meta.abc === "A") inferredStockoutA++;
+          else inferredStockoutB++;
+        }
+      }
+    }
+
+    const inferredTotal = inferredStockoutA + inferredStockoutB;
+    const stockoutInferred = !psnaps && inferredTotal > 0;
+
+    return {
+      period: p,
+      stockoutA: psnaps ? stockoutA : inferredStockoutA,
+      stockoutB: psnaps ? stockoutB : inferredStockoutB,
+      stockoutPct: psnaps
+        ? (abSkuCount > 0 ? Math.round((stockoutCount / abSkuCount) * 1000) / 10 : null)
+        : (stockoutInferred && inferredAbBase > 0 ? Math.round((inferredTotal / inferredAbBase) * 1000) / 10 : null),
+      overstockCount: psnaps ? overstockCount : null,
+      deadStockCount: deadCount,
+      deadStockValueKes: Math.round(deadValue),
+      missedRevenueKes: missedRevenue,
+      stockoutInferred,
+    };
+  });
+}
+
+const abcOf = (c: string | null): "A" | "B" | "C" | null => (c === "A" || c === "B" || c === "C" ? c : null);
+
+/** Build the report: the last `periods` completed periods (trend) + current
+ *  needs-attention/restock lists. null when the tenant is gone. */
+export async function buildOwnerReport(
+  tenantId: string,
+  granularity: ReportGranularity,
+  periods = 6,
+): Promise<OwnerReport | null> {
+  // eslint-disable-next-line tenant-safety/require-tenant-scope -- reads one tenant by the id the job already carries; the worker has no session, so there is no resolver to route through.
+  const tenant = await prismaService.tenant.findUnique({
+    where: { id: tenantId },
+    select: { name: true, slug: true, currency: true },
+  });
+  if (!tenant) return null;
+
+  // ── Trend: recompute the last `periods` completed periods ──
+  const now = new Date(); now.setUTCHours(0, 0, 0, 0);
+  const periodKeys = completedPeriods(now, granularity, periods);
+  const trend: TrendRow[] = [];
+  if (periodKeys.length > 0) {
+    const firstKey = periodKeys[0] as string;
+    const windowStart = periodStartDate(firstKey, granularity);
+    const endBound = granularity === "month"
+      ? new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+      : periodStartDate(isoWeekKey(now), "week");
+    // Sales look back further than the snapshot window: the weekly dead-stock /
+    // inferred-stockout tests read trailing weeks before periods[0].
+    const salesSince = new Date(windowStart);
+    if (granularity === "week") salesSince.setUTCDate(salesSince.getUTCDate() - 12 * 7);
+    const fmt = granularity === "week" ? 'IYYY-"W"IW' : "YYYY-MM";
+    const gran = granularity; // Postgres date_trunc unit: "week" | "month"
+
+    const [salesRows, snapRows, prods, snapDayRows] = await Promise.all([
+       
+      prismaService.$queryRaw<{ period: string; pid: string; qty: number; rev: number }[]>`
+        SELECT to_char(date_trunc(${gran}::text, date), ${fmt}) AS period, "productId" AS pid,
+               SUM(quantity)::float8 AS qty, SUM("revenueKes")::float8 AS rev
+        FROM "SalesHistory" WHERE "tenantId" = ${tenantId} AND date >= ${salesSince} AND date < ${endBound}
+        GROUP BY period, pid`,
+       
+      prismaService.$queryRaw<{ period: string; pid: string; minoh: number; endoh: number; daysout: number }[]>`
+        SELECT to_char(date_trunc(${gran}::text, s.date), ${fmt}) AS period, s."productId" AS pid,
+               MIN(s."onHand")::float8 AS minoh,
+               (ARRAY_AGG(s."onHand" ORDER BY s.date DESC))[1]::float8 AS endoh,
+               COUNT(*) FILTER (WHERE s."onHand" <= 0)::float8 AS daysout
+        FROM "InventorySnapshot" s
+        WHERE s."tenantId" = ${tenantId} AND s.date >= ${windowStart} AND s.date < ${endBound}
+        GROUP BY period, s."productId"`,
+       
+      prismaService.product.findMany({
+        where: { tenantId },
+        select: { id: true, abcCategory: true, costKes: true, priceKes: true },
+      }),
+       
+      prismaService.$queryRaw<{ period: string; snapdays: number }[]>`
+        SELECT to_char(date_trunc(${gran}::text, s.date), ${fmt}) AS period, COUNT(DISTINCT s.date::date)::int AS snapdays
+        FROM "InventorySnapshot" s WHERE s."tenantId" = ${tenantId} AND s.date >= ${windowStart} AND s.date < ${endBound}
+        GROUP BY period`,
+    ]);
+
+    const snapDays = new Map(snapDayRows.map((r) => [r.period, Number(r.snapdays)]));
+    const salesRevByPeriod = new Map<string, number>();
+    for (const r of salesRows) salesRevByPeriod.set(r.period, (salesRevByPeriod.get(r.period) ?? 0) + (Number(r.rev) || 0));
+    const products = new Map<string, ProductMeta>(
+      prods.map((p) => [p.id, { abc: p.abcCategory, costKes: p.costKes ?? 0, priceKes: p.priceKes ?? 0 }])
+    );
+    const deadStockWindowDays = await getDeadStockWindowDays(tenantId);
+    const health = stockHealthByPeriod({
+      periods: periodKeys,
+      granularity,
+      snaps: snapRows.map((r) => ({ period: r.period, pid: r.pid, minOh: Number(r.minoh), endOh: Number(r.endoh), daysOut: Number(r.daysout) || 0 })),
+      sales: salesRows.map((r) => ({ period: r.period, pid: r.pid, qty: Number(r.qty) || 0 })),
+      products,
+      deadStockWindowDays,
+    });
+    // newest first
+    for (const h of [...health].reverse()) {
+      const d = snapDays.get(h.period) ?? 0;
+      trend.push({
+        label: labelFor(h.period, periodStartDate(h.period, granularity)),
+        salesKes: Math.round(salesRevByPeriod.get(h.period) ?? 0),
+        stockoutA: h.stockoutA,
+        stockoutB: h.stockoutB,
+        stockoutPct: h.stockoutPct,
+        overstockCount: h.overstockCount,
+        deadCount: h.deadStockCount,
+        deadValueKes: h.deadStockValueKes,
+        missedRevenueKes: h.missedRevenueKes,
+        partial: d > 0 && d < (granularity === "week" ? 6 : 24),
+        inferred: h.stockoutInferred,
+      });
+    }
+  }
+
+  // ── Needs attention + restock: from the latest forecast run's predictions ──
+  const runId = await latestForecastRunId(tenantId);
+  const preds = runId
+     
+    ? await prismaService.prediction.findMany({
+        where: { tenantId, forecastRunId: runId },
+        select: {
+          finalForecast30d: true, daysUntilStockout: true, recommendedQty: true, urgency: true,
+          product: { select: { title: true, sku: true, active: true, currentStock: true, onOrder: true, costKes: true, priceKes: true, abcCategory: true } },
+        },
+      })
+    : [];
+
+  const classRank = (c: string | null) => (c === "A" ? 0 : c === "B" ? 1 : 2);
+  const urgencyRank = (u: string) => (u === "critical" ? 0 : u === "high" ? 1 : u === "medium" ? 2 : 3);
+
+  // Needs attention: A/B bestsellers currently at/near zero, still selling.
+  const needsAttention: AttentionLine[] = preds
+    .filter((p) => {
+      if (!p.product.active) return false;
+      const cls = p.product.abcCategory;
+      if (cls !== "A" && cls !== "B") return false;
+      const eff = p.product.currentStock + p.product.onOrder;
+      const rate = p.finalForecast30d / 30;
+      return rate > 0 && (eff <= 0 || eff / rate < 3);
+    })
+    .sort((a, b) => classRank(a.product.abcCategory) - classRank(b.product.abcCategory) || a.daysUntilStockout - b.daysUntilStockout)
+    .slice(0, 8)
+    .map((p) => ({
+      title: p.product.title, sku: p.product.sku, abc: abcOf(p.product.abcCategory),
+      onHand: Math.round(p.product.currentStock), enRoute: Math.round(p.product.onOrder),
+    }));
+
+  // Restock: plannable buy lines (valid cost/price), qty already nets on-hand +
+  // en route. Ranked urgency → class → soonest out. Budget = full cost.
+  const isPlannable = (p: { costKes: number; priceKes: number }) => p.costKes > 0 && p.priceKes > 0 && p.costKes <= p.priceKes;
+  const buy = preds
+    .filter((p) => p.product.active && p.recommendedQty > 0 && isPlannable(p.product))
+    .sort((a, b) =>
+      urgencyRank(a.urgency) - urgencyRank(b.urgency) ||
+      classRank(a.product.abcCategory) - classRank(b.product.abcCategory) ||
+      a.daysUntilStockout - b.daysUntilStockout);
+  const restockBudgetKes = Math.round(buy.reduce((s, p) => s + Math.ceil(p.recommendedQty) * (p.product.costKes ?? 0), 0));
+  const restock: RestockLine[] = buy.slice(0, 12).map((p) => ({
+    title: p.product.title, sku: p.product.sku, abc: abcOf(p.product.abcCategory),
+    qty: Math.ceil(p.recommendedQty), costKes: Math.round(Math.ceil(p.recommendedQty) * (p.product.costKes ?? 0)),
+    daysLeft: p.daysUntilStockout,
+  }));
+
+  // ── Transfers (warehouse→branch) ──
+  // Equalise days-of-cover across selling branches by moving stock out of the
+  // holding warehouse, using the SAME pure sizing engine the distribution page
+  // runs (`sizeTransfers`/`destinationShares` from @wezesha/forecast) so the
+  // email can't propose a move the app wouldn't. Best-effort: any failure here
+  // leaves the transfers section empty rather than failing the whole report.
+  let transfers: TransferLine[] = [];
+  let transferCount = 0;
+  let transferFrom = "";
+  try {
+    const built = await buildTransfers(tenantId);
+    transfers = built.lines.slice(0, 12);
+    transferCount = built.lines.length;
+    transferFrom = built.fromName;
+  } catch {
+    // leave the section empty on any transfer-side failure
+  }
+
+  return {
+    tenantName: tenant.name ?? tenant.slug,
+    currency: tenant.currency ?? "KES",
+    granularity,
+    latestLabel: trend[0]?.label ?? (granularity === "week" ? "this week" : "this month"),
+    trend,
+    needsAttention,
+    restock,
+    restockBudgetKes,
+    restockCount: buy.length,
+    transfers,
+    transferCount,
+    transferFrom,
+    hasData: trend.length > 0,
+  };
+}
+
+/** Trailing window for attributing branch demand — matches the distribution
+ *  page's default. */
+const TRANSFER_WINDOW_DAYS = 90;
+/** Cover level the transfer plan equalises branches to. */
+const TRANSFER_COVER_DAYS = 14;
+
+/**
+ * Build the top warehouse→branch moves for the report, using the shared pure
+ * sizing engine. Picks the holding location with the most stock as the source,
+ * splits each product's blended run rate across branches by their attributed
+ * sales (falling back to stock share), and level-fills every branch to a common
+ * days-of-cover. Returns lines already sorted by class then quantity.
+ */
+async function buildTransfers(
+  tenantId: string
+): Promise<{ lines: TransferLine[]; fromName: string }> {
+  const since = new Date(Date.now() - TRANSFER_WINDOW_DAYS * 86_400_000);
+   
+  const locations = await prismaService.location.findMany({
+    where: { tenantId },
+    select: { id: true, name: true, locationType: true },
+  });
+  const sells = locations.filter((l) => roleOf(l) === "sells");
+  const holds = locations.filter((l) => roleOf(l) === "holds");
+  if (sells.length === 0 || holds.length === 0) return { lines: [], fromName: "" };
+
+   
+  const levels = await prismaService.inventoryLevel.findMany({
+    where: { tenantId },
+    select: { productId: true, locationId: true, onHand: true },
+  });
+   
+  const attributed = await prismaService.salesHistory.groupBy({
+    by: ["productId", "locationId"],
+    where: { tenantId, date: { gte: since }, locationId: { not: null } },
+    _sum: { quantity: true },
+  });
+   
+  const products = await prismaService.product.findMany({
+    where: { tenantId },
+    select: { id: true, title: true, abcCategory: true },
+  });
+
+  // Source = the holding location carrying the most units.
+  const onHandAt = new Map<string, Map<string, number>>(); // productId -> locationId -> onHand
+  for (const lvl of levels) {
+    let byLoc = onHandAt.get(lvl.productId);
+    if (!byLoc) onHandAt.set(lvl.productId, (byLoc = new Map()));
+    byLoc.set(lvl.locationId, lvl.onHand);
+  }
+  const heldTotal = (locId: string) =>
+    levels.filter((l) => l.locationId === locId).reduce((s, l) => s + Math.max(0, l.onHand), 0);
+  const source = [...holds].sort((a, b) => heldTotal(b.id) - heldTotal(a.id))[0]!;
+
+  const attrAt = new Map<string, Map<string, number>>(); // productId -> locationId -> units
+  for (const row of attributed) {
+    if (!row.locationId) continue;
+    let byLoc = attrAt.get(row.productId);
+    if (!byLoc) attrAt.set(row.productId, (byLoc = new Map()));
+    byLoc.set(row.locationId, row._sum.quantity ?? 0);
+  }
+  const metaById = new Map(products.map((p) => [p.id, p]));
+  const classRank = (c: string | null) => (c === "A" ? 0 : c === "B" ? 1 : 2);
+
+  const lines: TransferLine[] = [];
+  for (const [productId, byLoc] of onHandAt) {
+    const available = byLoc.get(source.id) ?? 0;
+    if (available <= 0) continue;
+
+    // The product's blended run rate over the window (all attributed branches).
+    const attrByBranch = attrAt.get(productId) ?? new Map<string, number>();
+    const blended =
+      [...attrByBranch.values()].reduce((s, q) => s + Math.max(0, q), 0) / TRANSFER_WINDOW_DAYS;
+    if (blended <= 0) continue; // nothing sells it — nothing to cover
+
+    const destInputs = sells.map((b) => ({
+      locationId: b.id,
+      onHand: byLoc.get(b.id) ?? 0,
+      attributedUnits: attrByBranch.get(b.id) ?? 0,
+    }));
+    const { shareByLocation } = destinationShares(destInputs);
+    const positions: DestinationPosition[] = destInputs.map((d) => ({
+      locationId: d.locationId,
+      onHand: d.onHand,
+      runRate: blended * (shareByLocation.get(d.locationId) ?? 0),
+    }));
+
+    const sized = sizeTransfers(available, positions, TRANSFER_COVER_DAYS);
+    const meta = metaById.get(productId);
+    const branchName = new Map(sells.map((b) => [b.id, b.name]));
+    for (const move of sized) {
+      lines.push({
+        title: meta?.title ?? productId,
+        abc: abcOf(meta?.abcCategory ?? null),
+        qty: move.qty,
+        toBranch: branchName.get(move.toLocationId) ?? "",
+      });
+    }
+  }
+
+  lines.sort((a, b) => classRank(a.abc) - classRank(b.abc) || b.qty - a.qty);
+  return { lines, fromName: source.name };
+}

--- a/apps/worker/tests/crons.test.ts
+++ b/apps/worker/tests/crons.test.ts
@@ -146,13 +146,16 @@ describe.skipIf(!runnable)("email crons (real redis + db)", () => {
     const send = async (message: EmailMessage) => {
       sent.push(message);
     };
+    // The weekly path now sends the rich owner report (week-by-week trend),
+    // built via buildOwnerReport + renderReportEmail, under the same
+    // "weekly_summary" opt-out kind.
     await expect(crons.sendWeeklySummary(tenantId, send)).resolves.toBe(true);
     expect(sent).toHaveLength(1);
     expect(sent[0]!.to).toBe(ALERT_EMAIL);
-    expect(sent[0]!.subject).toBe("Weekly stock summary — Crons Test");
-    expect(sent[0]!.text).toContain("Revenue, last 30 days: KES 8,600");
-    expect(sent[0]!.text).toContain("Products stocked out right now: 1");
-    expect(sent[0]!.text).toContain("Marula Oil 50ml");
+    expect(sent[0]!.subject).toContain("Weekly report — Crons Test");
+    expect(sent[0]!.kind).toBe("weekly_summary");
+    expect(sent[0]!.html).toContain("How your shop is trending");
+    expect(sent[0]!.text).toContain("Weekly report — Crons Test");
   });
 
   it("labels the money in the workspace's own currency", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
     "apps/web": {
       "version": "0.1.0",
       "dependencies": {
+        "@react-pdf/renderer": "^4.9.0",
         "@wezesha/db": "*",
         "@wezesha/forecast": "*",
         "@wezesha/forecast-run": "*",
@@ -854,6 +855,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1787,9 +1797,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1805,9 +1812,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1825,9 +1829,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1843,9 +1844,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1863,9 +1861,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1881,9 +1876,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1901,9 +1893,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1920,9 +1909,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1938,9 +1924,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1964,9 +1947,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1988,9 +1968,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2014,9 +1991,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2038,9 +2012,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2064,9 +2035,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2089,9 +2057,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2113,9 +2078,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2414,9 +2376,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2432,9 +2391,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2452,9 +2408,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2470,9 +2423,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2813,6 +2763,181 @@
         "@prisma/debug": "6.19.3"
       }
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.1.2.tgz",
+      "integrity": "sha512-RT/jiGWIRjIC9c4S9NiqhEyfuA6YL+DtWL3Rm+k+zQhfeHYvHwGzFxr7ZJzThIMrT8sIQy+mpvFvfYyitEei/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/types": "^2.14.0",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4",
+        "pdfkit": "0.20.1"
+      }
+    },
+    "node_modules/@react-pdf/hyphenate": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/hyphenate/-/hyphenate-0.1.0.tgz",
+      "integrity": "sha512-CWulbuusHh2Lnos9ZffT3ZYfjCt332Yl8wjSyCKWbwhbTpe/VdFt53fM5elPp3HU3R6tzH6j3oYlLXDwC2WEHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphen": "~1.6.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.2.tgz",
+      "integrity": "sha512-89vlvZCCv1hPunFtyeS2rJTRL8h2yYmTI97AM4ppibS79zGsPFbqz/YrAunndcHB9uwGdn5S3+5k18mj0L2vkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.1",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-5.2.0.tgz",
+      "integrity": "sha512-Hzf9cShT1bKkr9tZ+A9qK/wHqUloOCgbNer72EquQS6QzqVGiDdtt6Wh9lQXwkd89U7yZolTLnFqP/dRdoRROw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.2",
+        "@react-pdf/paginate": "1.0.1",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/stylesheet": "^6.3.2",
+        "@react-pdf/textkit": "^7.0.1",
+        "@react-pdf/types": "^2.14.0",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/paginate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/paginate/-/paginate-1.0.1.tgz",
+      "integrity": "sha512-JN6teDqkdpkcRhdGZqyrr7Y8flgTtyI8XS3yaBQLyiGjEBPbR9m/19cz2z3JkqYpApau5pEHZlLjwGqMurWysw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.4.0.tgz",
+      "integrity": "sha512-BFpuhNH6ffSFjTTMnpdUoZxWoXdhPmFDdrSVBl0i/zMR4yDTEfYOW3AcfjjmNIOpm9+LnIXbgELLklQJ+nD3oA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.7.0.tgz",
+      "integrity": "sha512-UEMgR7gBmCJiKpuu9alY6QeZVNB+7b4DGHc7Hi8QIl+5PfHvyq+TV70N7+ngZ6wN7hF3XSiWz7GDuYxPIx5eRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/textkit": "^7.0.1",
+        "@react-pdf/types": "^2.14.0",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.9.0.tgz",
+      "integrity": "sha512-RAbARMwjcSYEpqpaWoWXz0uOGF1HjAl5hdJr889r5mgkPhF9xhX4CXSvcEbLTgFVj+KWbcar31MzcXYoANk/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.1.2",
+        "@react-pdf/layout": "^5.2.0",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.7.0",
+        "@react-pdf/types": "^2.14.0",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "pdfkit": "0.20.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.3.2.tgz",
+      "integrity": "sha512-UR247sNBx2k3RdL8JUCpUiyx39yQsUABagv3uAi91iMZCORE+fSCsOh7MOcEImmpms4GihydLGudbngI5g14PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.14.0",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^2.0.0",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.1.tgz",
+      "integrity": "sha512-m1GmGxV2wg/3VpoQ0aCJ598fBedCCfN+HtxKx1lq5kdwUWEaTbfXI1DGFAUedprFDd/i24okKFaUhV/KVZIqIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.4.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-7.0.1.tgz",
+      "integrity": "sha512-ljY/YoEETIOR/+zxWdLLmKlupz8/nBsbmxglM3mDRco62UEzEPnIeMEzYVVVraovCAJC2t+50gKFNSV17FYxbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/hyphenate": "^0.1.0",
+        "bidi-js": "^1.0.2",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-TYHpThdf2sz/d1g+CP9nWjYCJ8BYBUN5ORL6+60A85Js9S/YouK8OXzi+hDpYUSZJTOdYXdRxUNeG2oW8//Ulg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.1.2",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/stylesheet": "^6.3.2"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -2900,9 +3025,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +3040,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2938,9 +3057,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2956,9 +3072,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2976,9 +3089,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2994,9 +3104,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3379,9 +3486,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3399,9 +3503,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3419,9 +3520,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3439,9 +3537,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4030,9 +4125,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4047,9 +4139,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4064,9 +4153,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4081,9 +4167,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4098,9 +4181,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4115,9 +4195,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4132,9 +4209,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4149,9 +4223,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4166,9 +4237,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4183,9 +4251,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4430,6 +4495,12 @@
     "node_modules/@wezesha/ws-gateway": {
       "resolved": "apps/ws-gateway",
       "link": true
+    },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -4743,6 +4814,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
@@ -4880,6 +4971,15 @@
         }
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
@@ -4902,6 +5002,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -5149,6 +5258,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
@@ -5177,6 +5295,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -5406,6 +5545,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -5470,6 +5615,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/empathic": {
@@ -6179,6 +6330,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -6223,7 +6383,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -6279,6 +6438,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -6343,6 +6508,23 @@
       "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -6700,6 +6882,27 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
+    "node_modules/hyphen": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.6.6.tgz",
+      "integrity": "sha512-XtqmnT+b9n5MX+MsqluFAVTIenbtC25iskW0Z+jLd+awfhA+ZbWKWQMIvLJccGoa2bM1R6juWJ27cZxIFOmkWw==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6750,6 +6953,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -7173,6 +7382,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -7251,6 +7466,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -7274,7 +7498,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7553,9 +7776,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7575,9 +7795,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -7599,9 +7816,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7621,9 +7835,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -7678,6 +7889,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7705,7 +7935,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7751,6 +7980,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-2.0.0.tgz",
+      "integrity": "sha512-FqNmlXKYrp5d3g7xEOMJb+6gXZE0fTssdyIQqYR4LbkifbNbS0hDylhNDOh8r6tCgLboHd8+mwgH2njgSYDpnQ==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8045,6 +8280,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
@@ -8074,7 +8318,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8302,6 +8545,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8353,6 +8602,44 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.20.1.tgz",
+      "integrity": "sha512-1rRXK6x5o8I/3dBrBzXfxibpHpkfCnIA7EBAES7pEpGFc/65inMLlA8SalGWpJfal7BGekxeLf6A30IOpQpc5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.3.0",
+        "@noble/hashes": "^1.8.0",
+        "fflate": "^0.8.3",
+        "fontkit": "^2.0.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/pdfkit/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/pdfkit/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -8488,6 +8775,14 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8526,6 +8821,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -8610,7 +8911,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8644,6 +8944,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -8702,7 +9011,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
@@ -8784,6 +9092,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -8840,6 +9157,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -9467,6 +9790,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -9497,6 +9826,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -9802,6 +10137,32 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -10263,6 +10624,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/packages/db/src/notify-prefs.ts
+++ b/packages/db/src/notify-prefs.ts
@@ -1,9 +1,10 @@
 /**
  * Which optional emails a workspace still wants.
  *
- * Only two messages are sent on the app's initiative rather than a person's:
- * the weekly summary, and the alert that a feed has stopped arriving. Those are
- * the ones a shop can silence. Everything else the app sends — an invite, a
+ * A handful of messages are sent on the app's initiative rather than a person's:
+ * the weekly summary, the monthly owner report, and the alert that a feed has
+ * stopped arriving. Those are the ones a shop can silence. Everything else the
+ * app sends — an invite, a
  * sign-in code, a password reset, the purchase order itself — is the answer to
  * something someone just did, and is deliberately not mutable here: a shop that
  * had switched off its own purchase-order emails would be a support call, not a
@@ -26,6 +27,7 @@
 
 export const OPTIONAL_EMAIL_KINDS = [
   "weekly_summary",
+  "monthly_report",
   "reconnect_alert",
   "first_suggestions",
 ] as const;
@@ -40,6 +42,10 @@ export const OPTIONAL_EMAIL_LABELS: Record<OptionalEmailKind, { title: string; b
   weekly_summary: {
     title: "Weekly stock summary",
     body: "One email a week: what sold, what needs restocking, and what is tying up cash.",
+  },
+  monthly_report: {
+    title: "Monthly owner report",
+    body: "Once a month: how your shop is trending week by week, the bestsellers stocked out now, and this month's buy list.",
   },
   reconnect_alert: {
     title: "Sync stopped working",

--- a/packages/forecast-run/src/run.ts
+++ b/packages/forecast-run/src/run.ts
@@ -6,6 +6,7 @@ import {
   effectiveOnOrder,
   isSellable,
   outstandingByProduct,
+  prismaForTenant,
   prismaForTenantTx,
 } from "@wezesha/db";
 import {
@@ -26,6 +27,8 @@ import {
   windowsForProduct,
   expandPromoWindowsToDays,
   boundedMultiplier,
+  assessIngestHealth,
+  type IngestVerdict,
   type ActivePromo,
   type MonthlyExpectation,
   type DemandOverride,
@@ -111,7 +114,16 @@ function fullClosureDayKeys(
   return out;
 }
 
-export type ForecastRunResult = { created: number; forecastRunId: string };
+export type ForecastRunResult = {
+  created: number;
+  forecastRunId: string;
+  /** Set when the run was skipped to protect the last-good forecast — currently
+   *  only "ingest_stale" (the sales feed looked stopped, so nothing was written). */
+  skipped?: "ingest_stale";
+};
+
+/** Feed considered stopped past this — one notification per rolling window. */
+const INGEST_STALL_DEDUP_DAYS = 3;
 
 const r0 = (n: number) => Math.round(n);
 
@@ -120,6 +132,69 @@ function priorLabel(p: OwnerPriorFacts): string {
   if (p.expectedUnits != null) return `Owner expects ~${r0(p.expectedUnits)}/mo`;
   if (p.multiplier != null) return `Owner set ${p.multiplier}× for this ${p.scope}`;
   return "Owner prior applied";
+}
+
+/**
+ * Assess the whole tenant's ingest before forecasting. Rolls the loaded sales
+ * rows up into one units-per-day series (all products, all channels), excluding
+ * today (partial), and finds the newest sale timestamp — the two facts the pure
+ * `assessIngestHealth` needs to tell a stopped feed from a genuinely quiet shop.
+ */
+function assessTenantIngest(
+  sales: ReadonlyArray<{ date: Date; quantity: number }>,
+  now: Date
+): IngestVerdict {
+  const todayKey = dayKeyMs(now);
+  const byDay = new Map<number, number>();
+  let latestSaleAt: Date | null = null;
+  for (const row of sales) {
+    const key = dayKeyMs(row.date);
+    if (key >= todayKey) continue; // today is partial — judge completed days only
+    byDay.set(key, (byDay.get(key) ?? 0) + row.quantity);
+    if (latestSaleAt == null || row.date > latestSaleAt) latestSaleAt = row.date;
+  }
+  const daily = [...byDay.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([dayKey, units]) => ({ dayKey, units }));
+  // A shop that has barely ever sold has no established feed to call "stopped" —
+  // an empty history is a young tenant, not a broken feed. Only judge staleness
+  // once there is a real trading history to compare the silence against, so the
+  // gate never blocks a new shop's very first forecast.
+  const MIN_DAYS_TO_JUDGE = 14;
+  if (daily.filter((d) => d.units > 0).length < MIN_DAYS_TO_JUDGE) {
+    return { ok: true, stop: false, impute: false, gapDayKeys: [], reasons: [], stale: false, trailingNorm: 0 };
+  }
+  return assessIngestHealth(daily, latestSaleAt, now);
+}
+
+/**
+ * Tell the owner the feed looks stopped and the forecast was held. One bell
+ * notification per rolling window so a multi-day outage doesn't spam. Best-
+ * effort: the stall protection (keeping the last-good forecast) already
+ * happened; a failed notification write must not turn a safe skip into an error.
+ */
+async function raiseIngestStall(tenantId: string, verdict: IngestVerdict, now: Date): Promise<void> {
+  try {
+    const db = prismaForTenant(tenantId);
+    const dedupSince = new Date(now.getTime() - INGEST_STALL_DEDUP_DAYS * DAY_MS);
+    const recent = await db.notification.findFirst({
+      where: { kind: "forecast_held_stale_feed", createdAt: { gte: dedupSince } },
+      select: { id: true },
+    });
+    if (recent) return;
+    await db.notification.create({
+      data: {
+        tenantId,
+        kind: "forecast_held_stale_feed",
+        title: "Forecast paused — your sales feed looks stopped",
+        body:
+          `${verdict.reasons.join(" ")} We kept your last buy list rather than ` +
+          `telling you to order nothing off a gap. Reconnect the feed and it will refresh.`,
+      },
+    });
+  } catch {
+    // never let a bookkeeping failure undo a safe skip
+  }
 }
 
 export async function runForecast(tenantId: string): Promise<ForecastRunResult> {
@@ -265,6 +340,20 @@ export async function runForecast(tenantId: string): Promise<ForecastRunResult> 
     list.push(row.date);
   }
   const snapshotsSince = firstSnapshot?.date ?? undefined;
+
+  // ── Ingest-health gate: "no data ≠ no demand" ────────────────────────────
+  // A silently broken sales feed looks exactly like a shop that sold nothing.
+  // Forecasting off that hole would confidently tell the owner to order nothing
+  // for a month. Before writing a fresh forecast, sanity-check the ingest
+  // against the shop's own recent norm: if the feed is STALE (or too many recent
+  // days came in far below normal), keep the last-good predictions and alert the
+  // owner rather than overwrite them with a zero-demand run.
+  const ingest = assessTenantIngest(sales, now);
+  if (ingest.stop) {
+    await raiseIngestStall(tenantId, ingest, now);
+    // Keep the last-good forecast: return without touching Prediction rows.
+    return { created: 0, forecastRunId: "", skipped: "ingest_stale" };
+  }
 
   // Cross-product steps the pure pipeline leaves to the caller.
   const knobs = resolveForecastKnobs(config);

--- a/packages/forecast/src/index.ts
+++ b/packages/forecast/src/index.ts
@@ -118,6 +118,37 @@ export {
 // ABC classification
 export { assignAbc, dailySalesValue, type AbcInput, type AbcCategory } from "./abc";
 
+// ABC-class minimum serving rate
+export { applyAbcRateFloor, ABC_RATE_FLOORS } from "./rate-floor";
+
+// Ingest-health gate ("no data ≠ no demand")
+export {
+  assessIngestHealth,
+  DEFAULT_INGEST_HEALTH,
+  type DailyPoint,
+  type IngestHealthConfig,
+  type IngestVerdict,
+} from "./ingest-health";
+
+// Transfer sizing (pure engine, shared by web + worker)
+export {
+  sizeTransfers,
+  destinationShares,
+  clampCoverDays,
+  clampWindowDays,
+  NO_RATE_EPSILON,
+  DEFAULT_COVER_DAYS,
+  DEFAULT_WINDOW_DAYS,
+  COVER_DAY_CHOICES,
+  MIN_COVER_DAYS,
+  MAX_COVER_DAYS,
+  MIN_WINDOW_DAYS,
+  MAX_WINDOW_DAYS,
+  type DestinationPosition,
+  type SizedTransfer,
+  type RateBasis,
+} from "./transfers";
+
 // Tenant config resolution (pure)
 export {
   methodToPolicy,

--- a/packages/forecast/src/ingest-health.ts
+++ b/packages/forecast/src/ingest-health.ts
@@ -1,0 +1,133 @@
+/**
+ * Ingest-health gate — the "no data ≠ no demand" safety stop.
+ *
+ * A silent broken feed and a genuine zero look IDENTICAL in the numbers but mean
+ * the opposite. If the forecast runs off a hole, the app confidently tells the
+ * shop to order nothing for a month. So BEFORE re-forecasting a tenant we sanity-
+ * check the most recent ingest against the shop's OWN recent norm:
+ *
+ *   - STALE : the newest sale is older than `maxStaleHours` → the feed stopped.
+ *   - GAP   : one or more of the most-recent completed days came in far below the
+ *             shop's trailing norm → likely feed-gap days, not zero demand.
+ *
+ * On STALE (or too many gap days) we DON'T re-forecast — the caller keeps the
+ * last-good predictions and alerts the owner. A short recoverable gap (≤
+ * `maxImputeDays`) is IMPUTED: the gap day-keys are handed back so the caller can
+ * censor them from the run-rate denominator (the same mechanism as proven
+ * stockout days), and the forecast runs normally. We never invent sales.
+ *
+ * Pure: no I/O. The caller passes the daily series (excluding today, which is
+ * partial) and the newest sale timestamp.
+ */
+
+/** Per-day ingested units. `day` is a UTC-midnight epoch (ms) key. */
+export type DailyPoint = { dayKey: number; units: number };
+
+export type IngestHealthConfig = {
+  /** Feed considered stopped past this many hours with no new sale. */
+  maxStaleHours: number;
+  /** A day below this fraction of the trailing norm is a feed-gap day. */
+  lowFrac: number;
+  /** Don't second-guess a genuinely slow tiny shop: skip the gap check when the
+   *  trailing norm is below this many units/day. */
+  minNorm: number;
+  /** How many most-recent completed days to scan for gaps. */
+  imputeLookback: number;
+  /** ≤ this many gap days → IMPUTE and forecast; more → HARD STOP. */
+  maxImputeDays: number;
+};
+
+export const DEFAULT_INGEST_HEALTH: IngestHealthConfig = {
+  maxStaleHours: 36,
+  lowFrac: 0.2,
+  minNorm: 10,
+  imputeLookback: 7,
+  maxImputeDays: 2,
+};
+
+export type IngestVerdict = {
+  /** True = safe to write a fresh forecast. False = keep the last-good one. */
+  ok: boolean;
+  /** True = skip the run entirely (feed stale, or too many gap days to patch). */
+  stop: boolean;
+  /** True = a short recoverable gap: censor `gapDayKeys` and forecast normally. */
+  impute: boolean;
+  /** UTC-midnight day-keys to exclude from the run-rate denominator. */
+  gapDayKeys: number[];
+  /** Human-readable, for the owner alert. */
+  reasons: string[];
+  stale: boolean;
+  trailingNorm: number;
+};
+
+/** Value at quantile `f` (0..1) of the set; 0 when empty. */
+function quantile(xs: number[], f: number): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor(s.length * f))]!;
+}
+
+/**
+ * @param daily         per-day ingested units, ascending by dayKey, EXCLUDING
+ *                       today (today is partial — judge the last COMPLETED day).
+ * @param latestSaleAt  timestamp of the newest sale row (any channel).
+ * @param now           current time.
+ */
+export function assessIngestHealth(
+  daily: DailyPoint[],
+  latestSaleAt: Date | null,
+  now: Date,
+  cfg: IngestHealthConfig = DEFAULT_INGEST_HEALTH
+): IngestVerdict {
+  const reasons: string[] = [];
+
+  // Staleness — the feed stopped delivering entirely.
+  const staleHours =
+    latestSaleAt == null ? Infinity : (now.getTime() - latestSaleAt.getTime()) / 3_600_000;
+  const stale = staleHours > cfg.maxStaleHours;
+  if (stale) {
+    reasons.push(
+      latestSaleAt == null
+        ? "No sales data at all — the feed may never have connected."
+        : `No new sales for about ${Math.round(staleHours)}h — the feed looks stopped.`
+    );
+  }
+
+  // The "normal day" reference must resist a CLUSTER of recent gap days: if the
+  // feed has been down several days, plain-median would sink with them and hide
+  // the outage from itself. The upper-half (p75) of the window stays anchored to
+  // genuine trading days — a handful of broken days can't pull it down.
+  const prior = daily.slice(0, -1).map((d) => d.units);
+  const norm = quantile(prior.length ? prior : daily.map((d) => d.units), 0.75);
+  const lowThreshold = cfg.lowFrac * norm;
+
+  // Feed-gap days — recent completed days whose units are far below the norm.
+  // Only when the norm is meaningful, so a slow tiny shop isn't second-guessed.
+  const gapDayKeys: number[] = [];
+  if (norm >= cfg.minNorm) {
+    for (const d of daily.slice(-cfg.imputeLookback)) {
+      if (d.units < lowThreshold) gapDayKeys.push(d.dayKey);
+    }
+  }
+
+  // Decide: IMPUTE a short recoverable gap, or HARD-STOP a real outage.
+  let impute = false;
+  let stop = stale;
+  if (!stale && gapDayKeys.length > cfg.maxImputeDays) {
+    stop = true;
+    reasons.push(
+      `${gapDayKeys.length} of the last ${cfg.imputeLookback} days came in far below normal ` +
+        `(under ${Math.round(lowThreshold)} vs the usual ~${Math.round(norm)}/day) — too many ` +
+        `to safely patch. Forecast paused; the feed likely broke.`
+    );
+  } else if (!stale && gapDayKeys.length > 0) {
+    impute = true;
+    reasons.push(
+      `Ignored ${gapDayKeys.length} feed-gap day(s) that came in under ${Math.round(
+        cfg.lowFrac * 100
+      )}% of the usual ~${Math.round(norm)}/day — excluded from the rate, not counted as zero demand.`
+    );
+  }
+
+  return { ok: !stop, stop, impute, gapDayKeys, reasons, stale, trailingNorm: norm };
+}

--- a/packages/forecast/src/layered.ts
+++ b/packages/forecast/src/layered.ts
@@ -40,6 +40,8 @@ import {
   seasonalLabel,
   type MonthlyExpectation,
 } from "./seasonality";
+import { applyAbcRateFloor } from "./rate-floor";
+import type { AbcCategory } from "./abc";
 
 export type ActivePromo = {
   discountPct: number;
@@ -310,7 +312,7 @@ export function layeredForecast(input: ForecastInput): ForecastResult {
   const override = input.demandOverride ?? null;
 
   // ── Layer 1: recency-weighted run rate (or an external demand override) ────
-  const historyDailyRate = demandRateFor(
+  const rawHistoryDailyRate = demandRateFor(
     input.demandMethod ?? CHAMPION_DEFAULT,
     input.history,
     today,
@@ -320,6 +322,19 @@ export function layeredForecast(input: ForecastInput): ForecastResult {
       snapshotsSince: input.snapshotsSince,
     }
   );
+  // ABC-class rate floor: a bestseller stocked out for most of the window can
+  // have its censored rate decay toward zero and drop off the buy list. The
+  // floor serves an A/B product at a real minimum speed — but ONLY when it has
+  // proven recent demand, so a genuinely dead listing (no recent sales) stays
+  // at its computed rate and the dead-stock guard below still fires on it.
+  const floorWindowStart = new Date(today);
+  floorWindowStart.setUTCDate(floorWindowStart.getUTCDate() - 30);
+  const hadRecentSales = input.history.some((p) => p.quantity > 0 && p.date >= floorWindowStart);
+  const abcForFloor: AbcCategory | null =
+    input.abcCategory === "A" || input.abcCategory === "B" || input.abcCategory === "C"
+      ? input.abcCategory
+      : null;
+  const historyDailyRate = applyAbcRateFloor(rawHistoryDailyRate, abcForFloor, hadRecentSales);
   // The rate the inventory + sizing math runs on: the override when present
   // (cold-start borrow / owner expectation), else the history run rate.
   const dailyRate = override ? override.forecast30d / 30 : historyDailyRate;

--- a/packages/forecast/src/rate-floor.ts
+++ b/packages/forecast/src/rate-floor.ts
@@ -1,0 +1,60 @@
+/**
+ * ABC-class minimum serving rate.
+ *
+ * A bestseller that has been out of stock for most of a window can have its
+ * censored run rate decay toward zero — the shelf was empty, so few sales were
+ * recorded, so the rate says "barely sells", so the buy list under-orders the
+ * exact item that was starving. Censoring the denominator (see baseline.ts)
+ * helps, but on a near-total stockout there are too few in-stock days left to
+ * measure a rate from at all.
+ *
+ * The floor guarantees a Class-A (and, lower, Class-B) product a minimum daily
+ * rate so it is served at a real speed instead of vanishing off the buy list.
+ * Class C gets no floor — a slow mover reading as slow is correct.
+ *
+ * Crucially the floor only ever LIFTS a product that is genuinely a seller: it
+ * requires proof of real recent demand (`hadRecentSales`). It must never raise
+ * a dead listing's rate above zero — layeredForecast treats a zero history rate
+ * as "dead, never recommend", and a floor that resurrected it would put dead
+ * stock back on the buy list. So a product with no sales in the window is left
+ * exactly at its computed rate.
+ *
+ * Pure: the caller passes the computed rate, the class, and whether the product
+ * sold at all recently.
+ */
+
+import type { AbcCategory } from "./abc";
+
+/**
+ * Minimum daily units per ABC class. A ≈ one unit every ~2.5 days; B ≈ one unit
+ * every ~10 days; C none. Tunable constants — deliberately conservative so the
+ * floor rescues starved bestsellers without inventing demand for the long tail.
+ */
+export const ABC_RATE_FLOORS: Record<AbcCategory, number> = {
+  A: 0.4,
+  B: 0.1,
+  C: 0,
+};
+
+/**
+ * Lift a computed daily rate up to its ABC-class floor, but only for a product
+ * with proven recent demand. Returns the rate unchanged when:
+ *   - the class has no floor (C, or an unknown/unclassified class), or
+ *   - the product had no recent sales (`hadRecentSales` false) — flooring here
+ *     would resurrect a dead listing, and layeredForecast's dead-stock guard
+ *     keys off a zero rate, or
+ *   - the rate already meets or exceeds the floor.
+ *
+ * @param rate            the computed (censored) daily rate
+ * @param abc             the product's ABC class
+ * @param hadRecentSales  true if the product sold at least once in the rate window
+ */
+export function applyAbcRateFloor(
+  rate: number,
+  abc: AbcCategory | null | undefined,
+  hadRecentSales: boolean
+): number {
+  if (!hadRecentSales) return rate;
+  const floor = abc === "A" || abc === "B" ? ABC_RATE_FLOORS[abc] : 0;
+  return rate > floor ? rate : floor;
+}

--- a/packages/forecast/src/transfers.ts
+++ b/packages/forecast/src/transfers.ts
@@ -1,0 +1,194 @@
+/**
+ * Transfer sizing — the pure engine behind "what to move, from where to where".
+ *
+ * A distribution plan proposes moving stock out of one holding location so every
+ * selling location ends on the SAME days of cover at its own run rate. This
+ * module is the pure math: given a source's available units and each
+ * destination's on-hand + run-rate share, it sizes whole-unit moves that
+ * level-fill everyone to a common cover. No I/O, no Prisma — the caller supplies
+ * the positions (the web app from its metrics, the worker from its own rollup),
+ * so both share ONE sizing engine rather than two that can disagree.
+ */
+
+/** At or below this a destination has no measurable velocity — cover is
+ *  undefined there, so it receives nothing. */
+export const NO_RATE_EPSILON = 0.0001;
+
+/** Target days of cover a plan levels every destination up to. */
+export const DEFAULT_COVER_DAYS = 14;
+/** Trailing window used to attribute demand to a branch. */
+export const DEFAULT_WINDOW_DAYS = 90;
+/** Cover horizons offered on the screen. */
+export const COVER_DAY_CHOICES = [7, 14, 30] as const;
+/** Guard rails for anything a client can influence. */
+export const MIN_COVER_DAYS = 1;
+export const MAX_COVER_DAYS = 180;
+export const MIN_WINDOW_DAYS = 7;
+export const MAX_WINDOW_DAYS = 365;
+
+export type DestinationPosition = {
+  locationId: string;
+  /** On-hand at this destination today. Negative = oversold: a hole to backfill. */
+  onHand: number;
+  /** This destination's share of the product's run rate (units/day). */
+  runRate: number;
+};
+
+export type SizedTransfer = {
+  toLocationId: string;
+  /** Whole units to move. Never fractional, never more than the source holds. */
+  qty: number;
+  toOnHand: number;
+  toRunRate: number;
+  toDaysCoverBefore: number;
+  toDaysCoverAfter: number;
+};
+
+const roundTo1 = (value: number): number => Math.round(value * 10) / 10;
+
+/** Units a destination is short of a given cover level. Negative on-hand raises
+ *  the need — the hole is real stock the branch owes its shelf. */
+const shortfall = (d: DestinationPosition, level: number): number =>
+  Math.max(0, d.runRate * level - d.onHand);
+
+/**
+ * The highest common cover level the available units can lift every destination
+ * to (the classic level-fill). Exact rather than iterative: each destination
+ * starts needing stock at level `onHand / runRate`, so walking those breakpoints
+ * in order gives a segment on which the total need is linear in the level, and
+ * the level is solved directly on the first segment that fits.
+ */
+function fillLevel(destinations: DestinationPosition[], available: number): number {
+  const points = [...destinations].sort((a, b) => a.onHand / a.runRate - b.onHand / b.runRate);
+  let rate = 0;
+  let onHand = 0;
+  for (let i = 0; i < points.length; i++) {
+    rate += points[i]!.runRate;
+    onHand += points[i]!.onHand;
+    const next = points[i + 1];
+    const level = (available + onHand) / rate;
+    if (!next || level <= next.onHand / next.runRate) return level;
+  }
+  return 0; // unreachable: the last segment has no upper breakpoint
+}
+
+/**
+ * Size one product's move out of a source holding `available` units.
+ *
+ * The rule: level-fill to a common days-of-cover. Every destination is lifted to
+ * the same cover level — the target when the source can afford it, otherwise the
+ * highest level the source can reach for everyone. That is what "equalise cover"
+ * means; the alternative, splitting the shortfall proportionally, *preserves*
+ * the imbalance it is meant to remove (the branch that started emptiest stays
+ * emptiest), so it is used only to settle the rounding remainder below.
+ *
+ * The decisions this encodes, in order:
+ *
+ * 1. No run rate at a destination (`runRate <= NO_RATE_EPSILON`) → it receives
+ *    nothing. There is no cover to equalise, and shipping stock to a branch with
+ *    no measured demand manufactures the dead stock the product exists to kill.
+ * 2. The source holds none of the product (`available <= 0`) → no lines.
+ * 3. Already at or above the level → that destination gets nothing.
+ * 4. Source can't satisfy everyone → level-fill (above).
+ * 5. Rounding → floor each destination's fractional need, then hand the leftover
+ *    whole units out by largest fractional part (ties to the faster seller, then
+ *    by location id so the plan is deterministic).
+ */
+export function sizeTransfers(
+  available: number,
+  destinations: DestinationPosition[],
+  coverDays: number
+): SizedTransfer[] {
+  const units = Math.floor(Math.max(0, available));
+  const candidates = destinations.filter((d) => d.runRate > NO_RATE_EPSILON);
+  if (units <= 0 || candidates.length === 0) return [];
+
+  const needAtTarget = candidates.reduce((sum, d) => sum + shortfall(d, coverDays), 0);
+  if (needAtTarget <= 0) return [];
+
+  const level = needAtTarget <= units ? coverDays : fillLevel(candidates, units);
+
+  const wants = candidates
+    .map((d) => ({ d, want: shortfall(d, level) }))
+    .filter((w) => w.want > 0);
+  if (wants.length === 0) return [];
+
+  // Float slack on the total only: the level solve lands on sums like 3.999…7,
+  // and flooring that raw would silently strand a unit.
+  const budget = Math.min(units, Math.floor(wants.reduce((sum, w) => sum + w.want, 0) + 1e-9));
+  const qtyByLocation = new Map(wants.map((w) => [w.d.locationId, Math.floor(w.want)]));
+  let spare = budget - [...qtyByLocation.values()].reduce((sum, q) => sum + q, 0);
+
+  const byRemainder = [...wants].sort(
+    (a, b) =>
+      b.want - Math.floor(b.want) - (a.want - Math.floor(a.want)) ||
+      b.d.runRate - a.d.runRate ||
+      a.d.locationId.localeCompare(b.d.locationId)
+  );
+  for (const w of byRemainder) {
+    if (spare <= 0) break;
+    qtyByLocation.set(w.d.locationId, (qtyByLocation.get(w.d.locationId) ?? 0) + 1);
+    spare -= 1;
+  }
+
+  return wants
+    .map(({ d }) => {
+      const qty = qtyByLocation.get(d.locationId) ?? 0;
+      return {
+        toLocationId: d.locationId,
+        qty,
+        toOnHand: d.onHand,
+        toRunRate: d.runRate,
+        toDaysCoverBefore: roundTo1(Math.max(0, d.onHand) / d.runRate),
+        toDaysCoverAfter: roundTo1(Math.max(0, d.onHand + qty) / d.runRate),
+      };
+    })
+    .filter((line) => line.qty > 0);
+}
+
+/** How a product's per-destination run rate was derived — always shown, never
+ *  presented as if it were measured when it isn't. */
+export type RateBasis = "attributed" | "allocated" | "even";
+
+/**
+ * Split a product's blended run rate across destinations, in order of evidence:
+ *   "attributed" — the branch's own attributed sales in the window.
+ *   "allocated"  — no attributed sales anywhere: fall back to each branch's
+ *                  share of the stock it holds.
+ *   "even"       — neither signal (shop-wide stockout): split evenly.
+ */
+export function destinationShares(
+  destinations: { locationId: string; onHand: number; attributedUnits: number }[]
+): { basis: RateBasis; shareByLocation: Map<string, number> } {
+  const attributed = destinations.reduce((sum, d) => sum + Math.max(0, d.attributedUnits), 0);
+  if (attributed > 0) {
+    return {
+      basis: "attributed",
+      shareByLocation: new Map(
+        destinations.map((d) => [d.locationId, Math.max(0, d.attributedUnits) / attributed])
+      ),
+    };
+  }
+  const stocked = destinations.reduce((sum, d) => sum + Math.max(0, d.onHand), 0);
+  if (stocked > 0) {
+    return {
+      basis: "allocated",
+      shareByLocation: new Map(
+        destinations.map((d) => [d.locationId, Math.max(0, d.onHand) / stocked])
+      ),
+    };
+  }
+  const even = destinations.length > 0 ? 1 / destinations.length : 0;
+  return { basis: "even", shareByLocation: new Map(destinations.map((d) => [d.locationId, even])) };
+}
+
+/** Clamp a caller-supplied cover horizon into a plannable range. */
+export function clampCoverDays(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_COVER_DAYS;
+  return Math.min(MAX_COVER_DAYS, Math.max(MIN_COVER_DAYS, Math.round(value as number)));
+}
+
+export function clampWindowDays(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_WINDOW_DAYS;
+  return Math.min(MAX_WINDOW_DAYS, Math.max(MIN_WINDOW_DAYS, Math.round(value as number)));
+}

--- a/packages/forecast/tests/ingest-health.test.ts
+++ b/packages/forecast/tests/ingest-health.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  assessIngestHealth,
+  DEFAULT_INGEST_HEALTH,
+  type DailyPoint,
+} from "../src/ingest-health";
+
+const DAY = 86_400_000;
+
+/** A steady series of `n` completed days at `units`/day ending `endKey`. */
+function steady(n: number, units: number, endKey: number): DailyPoint[] {
+  const out: DailyPoint[] = [];
+  for (let i = n - 1; i >= 0; i--) out.push({ dayKey: endKey - i * DAY, units });
+  return out;
+}
+
+const now = new Date("2026-08-20T12:00:00Z");
+const lastCompletedKey = Date.UTC(2026, 7, 19); // Aug 19
+
+describe("assessIngestHealth", () => {
+  it("passes a healthy, fresh feed", () => {
+    const daily = steady(30, 20, lastCompletedKey);
+    const v = assessIngestHealth(daily, new Date("2026-08-20T06:00:00Z"), now);
+    expect(v.ok).toBe(true);
+    expect(v.stop).toBe(false);
+    expect(v.stale).toBe(false);
+    expect(v.gapDayKeys).toHaveLength(0);
+  });
+
+  it("STOPS when the newest sale is older than maxStaleHours", () => {
+    const daily = steady(30, 20, lastCompletedKey);
+    const old = new Date(now.getTime() - 48 * 3_600_000); // 48h ago > 36h default
+    const v = assessIngestHealth(daily, old, now);
+    expect(v.stale).toBe(true);
+    expect(v.stop).toBe(true);
+    expect(v.ok).toBe(false);
+    expect(v.reasons.join(" ")).toMatch(/feed looks stopped/i);
+  });
+
+  it("STOPS when the feed never connected (no latest sale)", () => {
+    const v = assessIngestHealth([], null, now);
+    expect(v.stop).toBe(true);
+    expect(v.reasons.join(" ")).toMatch(/never have connected/i);
+  });
+
+  it("IMPUTES a short recoverable gap (1-2 low days), does not stop", () => {
+    // 28 normal days then 2 near-empty days at the end.
+    const daily = [
+      ...steady(28, 20, lastCompletedKey - 2 * DAY),
+      { dayKey: lastCompletedKey - DAY, units: 0 },
+      { dayKey: lastCompletedKey, units: 1 },
+    ];
+    const v = assessIngestHealth(daily, new Date("2026-08-20T06:00:00Z"), now);
+    expect(v.stop).toBe(false);
+    expect(v.impute).toBe(true);
+    expect(v.gapDayKeys.length).toBeGreaterThan(0);
+    expect(v.gapDayKeys.length).toBeLessThanOrEqual(DEFAULT_INGEST_HEALTH.maxImputeDays);
+  });
+
+  it("STOPS when too many recent days are far below normal (real outage)", () => {
+    // 24 normal days then 5 near-empty days — more than maxImputeDays (2).
+    const daily = [
+      ...steady(24, 20, lastCompletedKey - 5 * DAY),
+      ...steady(5, 0, lastCompletedKey),
+    ];
+    const v = assessIngestHealth(daily, new Date("2026-08-20T06:00:00Z"), now);
+    expect(v.stop).toBe(true);
+    expect(v.reasons.join(" ")).toMatch(/too many to safely patch/i);
+  });
+
+  it("does not second-guess a genuinely slow tiny shop (norm below minNorm)", () => {
+    // ~2 units/day: below minNorm (10). A zero day is natural, not a gap.
+    const daily = [
+      ...steady(28, 2, lastCompletedKey - DAY),
+      { dayKey: lastCompletedKey, units: 0 },
+    ];
+    const v = assessIngestHealth(daily, new Date("2026-08-20T06:00:00Z"), now);
+    expect(v.gapDayKeys).toHaveLength(0);
+    expect(v.stop).toBe(false);
+  });
+
+  it("upper-half norm resists a cluster of gap days (outage not hidden)", () => {
+    // Feed down 4 of the last 7 days. A plain median would sink; p75 stays anchored
+    // to the trading days, so the outage is still detected as a STOP.
+    const daily = [
+      ...steady(23, 20, lastCompletedKey - 4 * DAY),
+      ...steady(4, 0, lastCompletedKey),
+    ];
+    const v = assessIngestHealth(daily, new Date("2026-08-20T06:00:00Z"), now);
+    expect(v.stop).toBe(true);
+  });
+});

--- a/packages/forecast/tests/rate-floor.test.ts
+++ b/packages/forecast/tests/rate-floor.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { applyAbcRateFloor, ABC_RATE_FLOORS } from "../src/rate-floor";
+import { layeredForecast, type ForecastInput } from "../src/layered";
+import type { SalesPoint } from "../src/baseline";
+
+describe("applyAbcRateFloor", () => {
+  it("lifts a starved Class-A seller to the A floor", () => {
+    expect(applyAbcRateFloor(0.05, "A", true)).toBe(ABC_RATE_FLOORS.A);
+  });
+
+  it("lifts a starved Class-B seller to the B floor", () => {
+    expect(applyAbcRateFloor(0.01, "B", true)).toBe(ABC_RATE_FLOORS.B);
+  });
+
+  it("leaves a rate already above the floor untouched", () => {
+    expect(applyAbcRateFloor(1.5, "A", true)).toBe(1.5);
+  });
+
+  it("does not floor Class C", () => {
+    expect(applyAbcRateFloor(0.02, "C", true)).toBe(0.02);
+  });
+
+  it("does not floor an unclassified product", () => {
+    expect(applyAbcRateFloor(0.02, null, true)).toBe(0.02);
+  });
+
+  it("never resurrects a dead listing (no recent sales)", () => {
+    // A product with no recent sales keeps its computed rate even if class A,
+    // so layeredForecast's dead-stock guard (zero rate) still fires.
+    expect(applyAbcRateFloor(0, "A", false)).toBe(0);
+  });
+});
+
+describe("layeredForecast applies the ABC floor", () => {
+  const today = new Date("2026-08-01T00:00:00Z");
+
+  // A Class-A product that sold recently but has been mostly stocked out, so its
+  // censored rate is tiny. History: a handful of recent sale days only.
+  function starvedHistory(): SalesPoint[] {
+    return [
+      { date: new Date("2026-07-28T00:00:00Z"), quantity: 1 },
+      { date: new Date("2026-07-30T00:00:00Z"), quantity: 1 },
+    ];
+  }
+
+  const baseInput = (over: Partial<ForecastInput>): ForecastInput => ({
+    productId: "p1",
+    productType: null,
+    vendor: null,
+    sku: "SKU1",
+    currentStock: 0,
+    abcCategory: "A",
+    history: starvedHistory(),
+    leadTimeAvg: 7,
+    leadTimeStd: 2,
+    activePromos: [],
+    runDateKey: "2026-08-01",
+    ...over,
+  });
+
+  it("a recently-selling Class-A item at zero stock is sized off the floored rate", () => {
+    // The floor lifts the sizing rate, so a stocked-out A bestseller gets a
+    // real reorder quantity instead of being under-ordered to ~nothing. (The
+    // displayed finalForecast30d can still be clipped by the best-month cap —
+    // the floor's job is the sizing math, which flows through the rate.)
+    const floored = layeredForecast(baseInput({}));
+    expect(floored.recommendedQty).toBeGreaterThan(0);
+    expect(floored.daysUntilStockout).toBe(0); // zero stock, real rate → out now
+  });
+
+  it("the floor lifts the reorder quantity vs the same item unclassified", () => {
+    const withFloor = layeredForecast(baseInput({ abcCategory: "A" }));
+    const noFloor = layeredForecast(baseInput({ abcCategory: "C" }));
+    // Same tiny history; A is floored to 0.4/day, C keeps the tiny censored
+    // rate — so A must recommend at least as much, and strictly more here.
+    expect(withFloor.recommendedQty).toBeGreaterThan(noFloor.recommendedQty);
+  });
+});


### PR DESCRIPTION
Ports the polish and correctness fixes the single-tenant original (`wezesha-restock`) had but the multitenant rewrite lacked. A sweep of the original's last two months of commits confirmed the core forecast fixes were already present in the rewrite — these five were the genuine gaps.

## User-facing
- **Branded PDF reports** — full-shop + generic per-section, via `@react-pdf/renderer`. `lib/reports/{report-pdf,section-pdf}.tsx`, `/api/reports/{pdf,section-pdf}`, `print-pdf` client + Export PDF on Insights. Reuses `getTodayMetrics` so the report can't disagree with the dashboard; cost columns gated on `view_costs`; timezone/currency from the tenant.
- **Monthly report + week-by-week trend email** — plus the weekly email upgraded to the same rich body. `apps/worker/src/owner-report{,-email}.ts` + a monthly BullMQ scheduler (`0 6 1 * *`). Recipients via `alertRecipients` over `Membership.user.email`, gated by `notifyPrefs` (new `monthly_report` kind).
- **CSV export gaps** — dedicated dead-stock CSV on the dashboard tab + full inventory-opportunity CSV on Insights, reusing `ExportBar`/`rowsToCsv`.

## Correctness
- **Ingest-health forecast gate** ("no data ≠ no demand") — a stale sales feed now hard-stops the run and **keeps the last-good forecast** + raises a bell, instead of overwriting the buy list with zero-demand output. New pure `packages/forecast/src/ingest-health.ts`, wired into `forecast-run/run.ts`. Only judges tenants with a real trading history, so a new shop's first run is never blocked.
- **ABC-class rate floor** — a bestseller stocked out for most of a window is served at a minimum daily rate (A ≈ 0.4, B ≈ 0.1/day) so it isn't under-ordered to nothing; never lifts an item without proven recent sales, so dead stock stays dead. New `packages/forecast/src/rate-floor.ts`.

## Refactor
- Extracted the pure transfer-sizing engine (`sizeTransfers`/`destinationShares`) from `apps/web/lib/data/transfers.ts` into `packages/forecast/src/transfers.ts` so the worker's owner report proposes the **same** warehouse→branch moves the distribution page would. Web re-exports it — no call-site changes.

## Verification
- New unit suites: rate-floor (8), ingest-health (7); transfers-sizing (13) now imports the package directly.
- All touched packages (`forecast`, `forecast-run`, `db`, `apps/web`, `apps/worker`) typecheck clean; tenant-safety eslint passes on every new file.
- DB-backed integration suites (forecast-run, crons) require `SERVICE_DATABASE_URL`/Redis — run separately.

## Notes
- The weekly email now sends the rich trend body (was thin plain-text); the direct `buildWeeklySummary`/`renderWeeklySummary` tests remain valid.
- QuickBooks and Odoo connectors from the original were intentionally left out (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)